### PR TITLE
Resolution for file shares and server storage absolute array indexing bugs

### DIFF
--- a/pkg/manager-nnf/manager.go
+++ b/pkg/manager-nnf/manager.go
@@ -1218,9 +1218,16 @@ func (*StorageService) StorageServiceIdFileSystemIdDelete(storageServiceId, file
 		return ec.NewErrNotFound().WithEvent(msgreg.ResourceNotFoundBase(FileSystemOdataType, fileSystemId))
 	}
 
-	for _, sh := range fs.shares {
-		if err := s.StorageServiceIdFileSystemIdExportedShareIdDelete(s.id, fs.id, sh.id); err != nil {
-			return ec.NewErrInternalServerError().WithResourceType(FileSystemOdataType).WithError(err).WithCause(fmt.Sprintf("Exported share '%s' failed delete", sh.id))
+	// Create a copy of file share IDs; The deletion of a share will modify the fs.shares[] so we cannot
+	// iterate on that array directly as it is editted in place.
+	shareIds := make([]string, len(fs.shares))
+	for idx, sh := range fs.shares {
+		shareIds[idx] = sh.id
+	}
+
+	for _, shid := range shareIds {
+		if err := s.StorageServiceIdFileSystemIdExportedShareIdDelete(s.id, fs.id, shid); err != nil {
+			return ec.NewErrInternalServerError().WithResourceType(FileSystemOdataType).WithError(err).WithCause(fmt.Sprintf("Exported share '%s' failed delete", shid))
 		}
 	}
 

--- a/pkg/manager-server/server_local.go
+++ b/pkg/manager-server/server_local.go
@@ -45,7 +45,7 @@ func (DefaultServerControllerProvider) NewServerController(opts ServerController
 }
 
 type LocalServerController struct {
-	storage []Storage
+	storage []*Storage
 }
 
 func (c *LocalServerController) Connected() bool { return true }
@@ -68,13 +68,16 @@ func (c *LocalServerController) GetServerInfo() ServerInfo {
 }
 
 func (c *LocalServerController) NewStorage(pid uuid.UUID, expectedNamespaces []StorageNamespace) *Storage {
-	c.storage = append(c.storage, Storage{
+
+	storage := &Storage{
 		Id:                   pid,
 		expectedNamespaces:   expectedNamespaces,
 		discoveredNamespaces: make([]StorageNamespace, 0),
 		ctrl:                 c,
-	})
-	return &c.storage[len(c.storage)-1]
+	}
+
+	c.storage = append(c.storage, storage)
+	return storage
 }
 
 func (c *LocalServerController) Delete(s *Storage) error {
@@ -220,9 +223,9 @@ func (c *LocalServerController) discoverViaNamespaces(s *Storage) error {
 }
 
 func (c *LocalServerController) findStorage(pid uuid.UUID) *Storage {
-	for idx, p := range c.storage {
-		if p.Id == pid {
-			return &c.storage[idx]
+	for idx, s := range c.storage {
+		if s.Id == pid {
+			return c.storage[idx]
 		}
 	}
 

--- a/pkg/manager-server/server_mock.go
+++ b/pkg/manager-server/server_mock.go
@@ -32,7 +32,7 @@ func NewMockServerController() ServerControllerApi {
 }
 
 type MockServerController struct {
-	storage []Storage
+	storage []*Storage
 }
 
 func (c *MockServerController) Connected() bool { return true }
@@ -44,12 +44,13 @@ func (m *MockServerController) GetServerInfo() ServerInfo {
 }
 
 func (c *MockServerController) NewStorage(pid uuid.UUID, expectedNamespaces []StorageNamespace) *Storage {
-	c.storage = append(c.storage, Storage{
+	storage := &Storage{
 		Id:                 pid,
 		expectedNamespaces: expectedNamespaces,
 		ctrl:               c,
-	})
-	return &c.storage[len(c.storage)-1]
+	}
+	c.storage = append(c.storage, storage)
+	return storage
 }
 
 func (c *MockServerController) Delete(s *Storage) error {


### PR DESCRIPTION
- Deletion of a file system's file shares was operating on the fs.shares array as it is being edited by the `StorageServiceIdFileSystemIdExportedShareIdDelete` method. Resolution here is to copy the fs.shares IDs into a array, and enumerate only on the share IDs

- Allocating ServerStorage was returning an absolute array index and deleting server storage could reshuffle the array. Thus any owners of the storage could be operating on the wrong array index, depending on how things were deleted. Resolution is to track the storage elements by pointer

Signed-off-by: Nate Roiger <nate.roiger@hpe.com>