### PR TITLE
Fix/delete

### DIFF
--- a/pkg/manager-nnf/persistent.go
+++ b/pkg/manager-nnf/persistent.go
@@ -90,9 +90,12 @@ func (*DefaultPersistentController) DeletePersistentObject(obj PersistentObjectA
 	if err != nil {
 		return err
 	}
-	defer ledger.Close()
 
-	return executePersistentObjectTransaction(ledger, obj, deleteFunc, startingState, endingState)
+	if err := executePersistentObjectTransaction(ledger, obj, deleteFunc, startingState, endingState); err != nil {
+		return err
+	}
+
+	return ledger.Close()
 }
 
 func executePersistentObjectTransaction(ledger *kvstore.Ledger, obj PersistentObjectApi, updateFunc func() error, startingState, endingState uint32) error {

--- a/pkg/manager-nnf/storage_group.go
+++ b/pkg/manager-nnf/storage_group.go
@@ -131,7 +131,23 @@ func (sg *StorageGroup) Rollback(state uint32) error {
 				return err
 			}
 		}
+
+	case storageGroupDeleteStartLogEntryType:
+		// Rollback to a state where all controllers are attached to the storage pool
+
+		sp := sg.storageService.findStoragePool(sg.storagePoolId)
+		if sp == nil {
+			return fmt.Errorf("Storage Pool %s not found", sg.storagePoolId)
+		}
+
+		for _, pv := range sp.providingVolumes {
+			if err := pv.storage.FindVolume(pv.volumeId).AttachController(sg.endpoint.controllerId); err != nil {
+				return err
+			}
+		}
 	}
+
+
 
 	return nil
 }

--- a/pkg/manager-nvme/manager.go
+++ b/pkg/manager-nvme/manager.go
@@ -572,9 +572,22 @@ func (v *Volume) DetachController(controllerId uint16) error {
 
 	for _, ctrlId := range controllerIds {
 		if ctrlId == controllerId {
-			if err := v.detach([]uint16{controllerId}); err != nil {
-				return err
-			}
+			return v.detach([]uint16{controllerId})
+		}
+	}
+
+	return nil
+}
+
+func (v *Volume) AttachController(controllerId uint16) error {
+	controllerIds, err := v.storage.device.ListAttachedControllers(v.namespaceId)
+	if err != nil {
+		return err
+	}
+
+	for _, ctrlId := range controllerIds {
+		if ctrlId == controllerId {
+			return v.attach([]uint16{controllerId})
 		}
 	}
 


### PR DESCRIPTION
- Failure to delete a persistent object should not delete the object key
- Support rollback of storage group delete; this rebuilds any storage group that might have been partially deleted.