### PR TITLE
Further fixes for File Share recovery

### DIFF
--- a/pkg/manager-nnf/file_system.go
+++ b/pkg/manager-nnf/file_system.go
@@ -92,18 +92,6 @@ func (fs *FileSystem) createFileShare(id string, sg *StorageGroup, mountRoot str
 	return &fs.shares[len(fs.shares)-1]
 }
 
-func (fs *FileSystem) updateFileShare(id string, mountRoot string) error {
-
-	for i := range fs.shares {
-		if fs.shares[i].id == id {
-			fs.shares[i].mountRoot = mountRoot
-			return nil
-		}
-	}
-
-	return fmt.Errorf("File share %s not found", id)
-}
-
 func (fs *FileSystem) deleteFileShare(sh *FileShare) {
 
 	sg := fs.storageService.findStorageGroup(sh.storageGroupId)

--- a/pkg/manager-nnf/file_system.go
+++ b/pkg/manager-nnf/file_system.go
@@ -126,7 +126,7 @@ type fileSystemPersistentMetadata struct {
 	FileSystemType string `json:"FileSystemType"`
 	FileSystemName string `json:"FileSystemName"`
 
-	server.FileSystemOem
+	server.FileSystemOem `json:",inline"`
 }
 
 func (fs *FileSystem) GetKey() string                       { return fileSystemRegistryPrefix + fs.id }

--- a/pkg/manager-server/file_system_api.go
+++ b/pkg/manager-server/file_system_api.go
@@ -80,7 +80,7 @@ type FileSystemApi interface {
 	Delete() error
 
 	Mount(mountpoint string) error
-	Unmount() error
+	Unmount(mountpoint string) error
 }
 
 // FileSystem - Represents an abstract file system, with individual operations
@@ -88,7 +88,6 @@ type FileSystemApi interface {
 type FileSystem struct {
 	name       string
 	devices    []string
-	mountpoint string
 }
 
 type FileSystemError struct {

--- a/pkg/manager-server/file_system_gfs2.go
+++ b/pkg/manager-server/file_system_gfs2.go
@@ -105,21 +105,17 @@ func (f *FileSystemGfs2) Mount(mountpoint string) error {
 		return err
 	}
 
-	f.mountpoint = mountpoint
-
 	return nil
 }
 
-func (f *FileSystemGfs2) Unmount() error {
-	if f.mountpoint == "" {
+func (f *FileSystemGfs2) Unmount(mountpoint string) error {
+	if mountpoint == "" {
 		return nil
 	}
 
-	if _, err := f.run(fmt.Sprintf("umount %s", f.mountpoint)); err != nil {
+	if _, err := f.run(fmt.Sprintf("umount %s", mountpoint)); err != nil {
 		return err
 	}
-
-	f.mountpoint = ""
 
 	return nil
 }

--- a/pkg/manager-server/file_system_lustre.go
+++ b/pkg/manager-server/file_system_lustre.go
@@ -179,25 +179,24 @@ func (f *FileSystemLustre) Mount(mountpoint string) error {
 	if err != nil {
 		return err
 	}
-	f.mountpoint = mountpoint
+
 	return nil
 }
 
-func (f *FileSystemLustre) Unmount() error {
-	if len(f.mountpoint) > 0 {
-		err := runCmd(f, fmt.Sprintf("umount %s", f.mountpoint))
+func (f *FileSystemLustre) Unmount(mountpoint string) error {
+	if len(mountpoint) > 0 {
+		err := runCmd(f, fmt.Sprintf("umount %s", mountpoint))
 		if err != nil {
 			return err
 		}
 	}
-	if err := os.Remove(f.mountpoint); err != nil {
+	if err := os.Remove(mountpoint); err != nil {
 		// Log anything other than ErrNotExist.
 		if os.IsNotExist(err) == false {
 			// Just log it, don't fuss over it.
-			log.Info("Unable to remove mountpoint; continuing", "mountpoint", f.mountpoint, "err", err)
+			log.Info("Unable to remove mountpoint; continuing", "mountpoint", mountpoint, "err", err)
 		}
 	}
-	f.mountpoint = ""
 
 	return nil
 }

--- a/pkg/manager-server/file_system_lvm.go
+++ b/pkg/manager-server/file_system_lvm.go
@@ -194,21 +194,18 @@ func (f *FileSystemLvm) Mount(mountpoint string) error {
 		return err
 	}
 
-	f.mountpoint = mountpoint
-
 	return nil
 }
 
-func (f *FileSystemLvm) Unmount() error {
-	if f.mountpoint == "" {
+func (f *FileSystemLvm) Unmount(mountpoint string) error {
+	if mountpoint == "" {
 		return nil
 	}
 
-	if _, err := f.run(fmt.Sprintf("umount %s", f.mountpoint)); err != nil {
+	if _, err := f.run(fmt.Sprintf("umount %s", mountpoint)); err != nil {
 		return err
 	}
 
-	f.mountpoint = ""
 	return nil
 }
 

--- a/pkg/manager-server/file_system_xfs.go
+++ b/pkg/manager-server/file_system_xfs.go
@@ -69,21 +69,19 @@ func (f *FileSystemXfs) Mount(mountpoint string) error {
 		return err
 	}
 
-	f.mountpoint = mountpoint
-
 	return nil
 }
 
-func (f *FileSystemXfs) Unmount() error {
-	if f.mountpoint == "" {
+func (f *FileSystemXfs) Unmount(mountpoint string) error {
+	if mountpoint == "" {
 		return nil
 	}
 
-	if _, err := f.run(fmt.Sprintf("umount %s", f.mountpoint)); err != nil {
+	if _, err := f.run(fmt.Sprintf("umount %s", mountpoint)); err != nil {
 		return err
 	}
 
-	f.mountpoint = ""
+	mountpoint = ""
 
 	return nil
 }

--- a/pkg/manager-server/file_system_zfs.go
+++ b/pkg/manager-server/file_system_zfs.go
@@ -57,12 +57,12 @@ func (f *FileSystemZfs) Create(devices []string, options FileSystemOptions) erro
 func (f *FileSystemZfs) Delete() error { return nil }
 
 func (f *FileSystemZfs) Mount(mountpoint string) error {
-	_, err := f.run(fmt.Sprintf("zpool create -m %s %s %s", f.mountpoint, f.name, strings.Join(f.devices, " ")))
+	_, err := f.run(fmt.Sprintf("zpool create -m %s %s %s", mountpoint, f.name, strings.Join(f.devices, " ")))
 
 	return err
 }
 
-func (f *FileSystemZfs) Unmount() error {
+func (f *FileSystemZfs) Unmount(mountpoint string) error {
 	_, err := f.run(fmt.Sprintf("zpool destroy %s", f.name))
 
 	return err

--- a/pkg/manager-server/server_api.go
+++ b/pkg/manager-server/server_api.go
@@ -76,6 +76,6 @@ type ServerControllerApi interface {
 
 	CreateFileSystem(*Storage, FileSystemApi, FileSystemOptions) error
 	DeleteFileSystem(*Storage, FileSystemApi) error
-	MountFileSystem(*Storage, FileSystemApi, FileSystemOptions) error
-	UnmountFileSystem(*Storage, FileSystemApi) error
+	MountFileSystem(*Storage, FileSystemApi, string) error
+	UnmountFileSystem(*Storage, FileSystemApi, string) error
 }

--- a/pkg/manager-server/server_disabled.go
+++ b/pkg/manager-server/server_disabled.go
@@ -58,11 +58,11 @@ func (*DisabledServerController) CreateFileSystem(*Storage, FileSystemApi, FileS
 	return ErrServerControllerDisabled
 }
 
-func (*DisabledServerController) MountFileSystem(*Storage, FileSystemApi, FileSystemOptions) error {
+func (*DisabledServerController) MountFileSystem(*Storage, FileSystemApi, string) error {
 	return ErrServerControllerDisabled
 }
 
-func (*DisabledServerController) UnmountFileSystem(*Storage, FileSystemApi) error {
+func (*DisabledServerController) UnmountFileSystem(*Storage, FileSystemApi, string) error {
 	return ErrServerControllerDisabled
 }
 

--- a/pkg/manager-server/server_local.go
+++ b/pkg/manager-server/server_local.go
@@ -117,8 +117,7 @@ func (c *LocalServerController) DeleteFileSystem(s *Storage, fs FileSystemApi) e
 	return fs.Delete()
 }
 
-func (c *LocalServerController) MountFileSystem(s *Storage, fs FileSystemApi, opts FileSystemOptions) error {
-	mountPoint := opts["mountpoint"].(string)
+func (c *LocalServerController) MountFileSystem(s *Storage, fs FileSystemApi, mountPoint string) error {
 	if mountPoint == "" {
 		return nil
 	}
@@ -130,8 +129,8 @@ func (c *LocalServerController) MountFileSystem(s *Storage, fs FileSystemApi, op
 	return nil
 }
 
-func (c *LocalServerController) UnmountFileSystem(s *Storage, fs FileSystemApi) error {
-	if err := fs.Unmount(); err != nil {
+func (c *LocalServerController) UnmountFileSystem(s *Storage, fs FileSystemApi, mountPoint string) error {
+	if err := fs.Unmount(mountPoint); err != nil {
 		return err
 	}
 

--- a/pkg/manager-server/server_mock.go
+++ b/pkg/manager-server/server_mock.go
@@ -79,14 +79,13 @@ func (*MockServerController) CreateFileSystem(s *Storage, fs FileSystemApi, opts
 	return nil
 }
 
-func (*MockServerController) MountFileSystem(s *Storage, fs FileSystemApi, opts FileSystemOptions) error {
+func (*MockServerController) MountFileSystem(s *Storage, fs FileSystemApi, mountpoint string) error {
 	if fs.IsMockable() {
-		mountPoint := opts["mountpoint"].(string)
-		if mountPoint == "" {
+		if mountpoint == "" {
 			return nil
 		}
 
-		if err := fs.Mount(mountPoint); err != nil {
+		if err := fs.Mount(mountpoint); err != nil {
 			return err
 		}
 	}
@@ -94,9 +93,9 @@ func (*MockServerController) MountFileSystem(s *Storage, fs FileSystemApi, opts 
 	return nil
 }
 
-func (*MockServerController) UnmountFileSystem(s *Storage, fs FileSystemApi) error {
+func (*MockServerController) UnmountFileSystem(s *Storage, fs FileSystemApi, mountpoint string) error {
 	if fs.IsMockable() {
-		if err := fs.Unmount(); err != nil {
+		if err := fs.Unmount(mountpoint); err != nil {
 			return err
 		}
 	}

--- a/pkg/manager-server/server_remote.go
+++ b/pkg/manager-server/server_remote.go
@@ -68,11 +68,11 @@ func (c *RemoteServerController) CreateFileSystem(*Storage, FileSystemApi, FileS
 	return fmt.Errorf("Cannot create file system on remote server")
 }
 
-func (r *RemoteServerController) MountFileSystem(*Storage, FileSystemApi, FileSystemOptions) error {
+func (r *RemoteServerController) MountFileSystem(*Storage, FileSystemApi, string) error {
 	return nil
 }
 
-func (r *RemoteServerController) UnmountFileSystem(*Storage, FileSystemApi) error {
+func (r *RemoteServerController) UnmountFileSystem(*Storage, FileSystemApi, string) error {
 	return nil
 }
 

--- a/pkg/manager-server/storage.go
+++ b/pkg/manager-server/storage.go
@@ -79,12 +79,12 @@ func (s *Storage) DeleteFileSystem(fs FileSystemApi) error {
 	return s.ctrl.DeleteFileSystem(s, fs)
 }
 
-func (s *Storage) MountFileSystem(fs FileSystemApi, opts FileSystemOptions) error {
-	return s.ctrl.MountFileSystem(s, fs, opts)
+func (s *Storage) MountFileSystem(fs FileSystemApi, mountPoint string) error {
+	return s.ctrl.MountFileSystem(s, fs, mountPoint)
 }
 
-func (s *Storage) UnmountFileSystem(fs FileSystemApi, opts FileSystemOptions) error {
-	return s.ctrl.UnmountFileSystem(s, fs)
+func (s *Storage) UnmountFileSystem(fs FileSystemApi, mountPoint string) error {
+	return s.ctrl.UnmountFileSystem(s, fs, mountPoint)
 }
 
 // Returns the list of devices for this pool.

--- a/pkg/tests/filesystem/file_system_test.go
+++ b/pkg/tests/filesystem/file_system_test.go
@@ -178,7 +178,7 @@ func (fs *testFileSystem) Mount(mountpoint string) error {
 	return nil
 }
 
-func (fs *testFileSystem) Unmount() error {
+func (fs *testFileSystem) Unmount(mountpoint string) error {
 	fs.t.Logf("Test File System: Unmount")
 
 	if fs.mountpoint == "" {
@@ -186,5 +186,6 @@ func (fs *testFileSystem) Unmount() error {
 	}
 
 	fs.mountpoint = ""
+
 	return nil
 }


### PR DESCRIPTION
I identified another issue with Lustre where the mount point, although it is stored in the recovery database, it's not loaded into the various implementations of the file system API. This caused an empty mountpoint so nothing was unmounted on delete, which caused the `zpool destroy` to fail with "cannot destroy 'lus-ostpool': pool is busy"

The file system object is really not the place to track the mount point since it is not persistent. It's solely in the file share data, so the API was changed to accept the mountpoint on the `Unmount()` call. The mountpoint was then removed from the FileSystem structure, making the file system "stateless"

I also corrected what I could in the file-share recovery code so the latest applied mountpoint is stored in the database. There's still some recovery code if we crash while in the process of mounting or unmounting - a future PR will handle that.