### PR TITLE
Add command option to debug.sh, "clear-nvm", to clear the switchtec n…

### DIFF
--- a/tools/rabbit-s.sh
+++ b/tools/rabbit-s.sh
@@ -82,7 +82,7 @@ case $CMD in
             screen -S $PAX -X colon "log on^M"
 EOF
         done
-        ;;        
+        ;;
     clear-logs)
         for SESSION in "${SESSIONS[@]}"
         do
@@ -90,7 +90,7 @@ EOF
         done
         ;;
     get-logs)
-        $SSHPASS scp root@$SYSTEM:~/*.log ./ 
+        $SSHPASS scp root@$SYSTEM:~/*.log ./
         ;;
     fabdbg-on)
         for SESSION in "${SESSIONS[@]}"


### PR DESCRIPTION
…on-volatile logs

Signed-off-by: Anthony Floeder <anthony.floeder@hpe.com>

I've installed the patched switchtec tool on:
tom-node
rabbit-node-1
rabbit-node-2