### PR TITLE
LVM/GFS2 file systems fail to recovery after sudden shutdown

### DIFF
--- a/pkg/manager-server/file_system_api.go
+++ b/pkg/manager-server/file_system_api.go
@@ -81,13 +81,16 @@ type FileSystemApi interface {
 
 	Mount(mountpoint string) error
 	Unmount(mountpoint string) error
+
+	GenerateRecoveryData() map[string]string
+	LoadRecoveryData(data map[string]string)
 }
 
 // FileSystem - Represents an abstract file system, with individual operations
 // defined by the underlying FileSystemApi implementation
 type FileSystem struct {
-	name       string
-	devices    []string
+	name    string
+	devices []string
 }
 
 type FileSystemError struct {

--- a/pkg/manager-server/file_system_gfs2.go
+++ b/pkg/manager-server/file_system_gfs2.go
@@ -68,6 +68,7 @@ func (*FileSystemGfs2) New(oem FileSystemOem) (FileSystemApi, error) {
 	return &FileSystemGfs2{
 		FileSystemLvm: FileSystemLvm{
 			FileSystem: FileSystem{name: oem.Name},
+			shared: true,
 		},
 		clusterName: oem.ClusterName,
 	}, nil
@@ -80,7 +81,7 @@ func (*FileSystemGfs2) Type() string                  { return "gfs2" }
 func (f *FileSystemGfs2) Name() string { return f.name }
 
 func (f *FileSystemGfs2) Create(devices []string, opts FileSystemOptions) error {
-	opts["shared"] = true
+
 	if err := f.FileSystemLvm.Create(devices, opts); err != nil {
 		return err
 	}

--- a/pkg/manager-server/file_system_lustre.go
+++ b/pkg/manager-server/file_system_lustre.go
@@ -201,6 +201,14 @@ func (f *FileSystemLustre) Unmount(mountpoint string) error {
 	return nil
 }
 
+func (f *FileSystemLustre) GenerateRecoveryData() map[string]string {
+	return map[string]string{}
+}
+
+func (f *FileSystemLustre) LoadRecoveryData(map[string]string) {
+
+}
+
 func (f *FileSystemLustre) zfsTargType() string {
 	return strings.ToLower(string(f.targetType))
 }

--- a/pkg/manager-server/file_system_lvm.go
+++ b/pkg/manager-server/file_system_lvm.go
@@ -26,6 +26,10 @@ import (
 	"strings"
 )
 
+const (
+	VolumeGroupName = "volumeGroupName"
+	LogicalVolumeName = "logicalVolumeName"
+)
 type FileSystemLvm struct {
 	// Satisfy FileSystemApi interface.
 	FileSystem
@@ -53,20 +57,16 @@ func (f *FileSystemLvm) Name() string { return f.name }
 
 func (f *FileSystemLvm) Create(devices []string, opts FileSystemOptions) error {
 
-	if _, exists := opts["volumeGroupName"]; exists {
-		f.vgName = opts["volumeGroupName"].(string)
+	if _, exists := opts[VolumeGroupName]; exists {
+		f.vgName = opts[VolumeGroupName].(string)
 	} else {
 		f.vgName = fmt.Sprintf("%s_vg", f.Name())
 	}
 
-	if _, exists := opts["logicalVolumeName"]; exists {
-		f.lvName = opts["logicalVolumeName"].(string)
+	if _, exists := opts[LogicalVolumeName]; exists {
+		f.lvName = opts[LogicalVolumeName].(string)
 	} else {
 		f.lvName = fmt.Sprintf("%s_lv", f.Name())
-	}
-
-	if _, exists := opts["shared"]; exists {
-		f.shared = opts["shared"].(bool)
 	}
 
 	// TODO: Some sort of rollback mechanism on failure condition
@@ -207,6 +207,18 @@ func (f *FileSystemLvm) Unmount(mountpoint string) error {
 	}
 
 	return nil
+}
+
+func (f *FileSystemLvm) GenerateRecoveryData() map[string]string {
+	return map[string]string{
+		VolumeGroupName: f.vgName,
+		LogicalVolumeName: f.lvName,
+	}
+}
+
+func (f *FileSystemLvm) LoadRecoveryData(data map[string]string) {
+	f.vgName = data[VolumeGroupName]
+	f.lvName = data[LogicalVolumeName]
 }
 
 func (f *FileSystemLvm) devPath() string {

--- a/pkg/manager-server/file_system_zfs.go
+++ b/pkg/manager-server/file_system_zfs.go
@@ -67,3 +67,11 @@ func (f *FileSystemZfs) Unmount(mountpoint string) error {
 
 	return err
 }
+
+func (f *FileSystemZfs) GenerateRecoveryData() map[string]string {
+	return map[string]string{}
+}
+
+func (f *FileSystemZfs) LoadRecoveryData(map[string]string) {
+
+}

--- a/pkg/persistent/debug/get_ec_data.sh
+++ b/pkg/persistent/debug/get_ec_data.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+k get nnfnodeecdata/ec-data -n "$1" -o json | jq .status.data > data.json

--- a/pkg/tests/filesystem/file_system_test.go
+++ b/pkg/tests/filesystem/file_system_test.go
@@ -171,7 +171,7 @@ func (fs *testFileSystem) Mount(mountpoint string) error {
 		fs.t.Fatal("Mount requires non empty mountpoint")
 	}
 	if fs.mountpoint != "" {
-		fs.t.Errorf("Teste File System: Mountpoint already present: Mountpoint: %s", fs.mountpoint)
+		fs.t.Errorf("Test File System: Mountpoint already present: Mountpoint: %s", fs.mountpoint)
 	}
 
 	fs.mountpoint = mountpoint
@@ -188,4 +188,12 @@ func (fs *testFileSystem) Unmount(mountpoint string) error {
 	fs.mountpoint = ""
 
 	return nil
+}
+
+func (f *testFileSystem) GenerateRecoveryData() map[string]string {
+	return map[string]string{}
+}
+
+func (f *testFileSystem) LoadRecoveryData(map[string]string) {
+
 }


### PR DESCRIPTION
Customized VG & LV values are not stored in the persistent database - this adds a new GenerateRecoveryData() method that ensures necessary file system / file share data is preserved. A corresponding LoadRecoveryData() is called by the replay handler to load the persistent data.

Signed-off-by: Nate Roiger <nate.roiger@hpe.com>