### PR TITLE
Added Slot/PartLocation support to Storage Controller

### DIFF
--- a/pkg/api/fabric.go
+++ b/pkg/api/fabric.go
@@ -19,15 +19,20 @@
 
 package api
 
+import openapi "github.com/NearNodeFlash/nnf-ec/pkg/rfsf/pkg/common"
+
 // FabricApi - Presents an API into the fabric outside of the fabric manager
 // TODO: This should be obsolete - the NVMe Namespace Manager can
-//       include the Fabric Manager (but NOT the other way around!!! Go doesn't
-//       support circular bindings.
+//
+//	include the Fabric Manager (but NOT the other way around!!! Go doesn't
+//	support circular bindings.
 type FabricControllerApi interface {
 	// Locates the index of the Downstream Port DSP within the Fabric Controller's list of all Downstream Endpoints, regardless of current endpoint status.
 	GetDownstreamPortRelativePortIndex(switchId, portId string) (int, error)
 
 	FindDownstreamEndpoint(portId, functionId string) (string, error)
+
+	GetPortPartLocation(switchId, portId string) (*openapi.PartLocation, error)
 }
 
 // FabricDeviceControllerApi defines the interface for controlling a device on the fabric.

--- a/pkg/manager-fabric/config.go
+++ b/pkg/manager-fabric/config.go
@@ -62,8 +62,9 @@ type SwitchConfig struct {
 	Metadata struct {
 		Name string
 	}
-	PciGen int32 `yaml:"pciGen"`
-	Ports  []PortConfig
+	PciGen     int32  `yaml:"pciGen"`
+	SlotPrefix string `yaml:"slotPrefix"`
+	Ports      []PortConfig
 
 	ManagementPortCount int
 	UpstreamPortCount   int
@@ -75,6 +76,7 @@ type PortConfig struct {
 	Name  string
 	Type  string
 	Port  int
+	Slot  int
 	Width int
 }
 

--- a/pkg/manager-fabric/config_default.yaml
+++ b/pkg/manager-fabric/config_default.yaml
@@ -7,6 +7,7 @@ switches:
     metadata:
       name: PAX 0
     pciGen: 4
+    slotPrefix: J
     ports:
       - name: Interswitch Fabric
         type: InterswitchPort
@@ -51,43 +52,53 @@ switches:
       - name: SSD 0
         type: DownstreamPort
         port: 8
+        slot: 13
         width: 4
       - name: SSD 1
         type: DownstreamPort
         port: 10
+        slot: 14
         width: 4
       - name: SSD 2
         type: DownstreamPort
         port: 12
+        slot: 18
         width: 4
       - name: SSD 3
         type: DownstreamPort
         port: 14
+        slot: 17
         width: 4
       - name: SSD 4
         type: DownstreamPort
         port: 16
+        slot: 16
         width: 4
       - name: SSD 5
         type: DownstreamPort
         port: 18
+        slot: 15
         width: 4
       - name: SSD 6
         type: DownstreamPort
         port: 20
+        slot: 7
         width: 4
       - name: SSD 7
         type: DownstreamPort
         port: 22
+        slot: 8
         width: 4
       - name: SSD 8
         type: DownstreamPort
         port: 48
+        slot: 12
         width: 4
   - id: 1
     metadata:
       name: PAX 1
     pciGen: 4
+    slotPrefix: J
     ports:
       - name: Interswitch Fabric
         type: InterswitchPort
@@ -132,36 +143,45 @@ switches:
       - name: SSD 9
         type: DownstreamPort
         port: 8
+        slot: 11
         width: 4
       - name: SSD 10
         type: DownstreamPort
         port: 10
+        slot: 10
         width: 4
       - name: SSD 11
         type: DownstreamPort
         port: 12
+        slot: 9
         width: 4
       - name: SSD 12
         type: DownstreamPort
         port: 14
+        slot: 1
         width: 4
       - name: SSD 13
         type: DownstreamPort
         port: 16
+        slot: 2
         width: 4
       - name: SSD 14
         type: DownstreamPort
         port: 18
+        slot: 6
         width: 4
       - name: SSD 15
         type: DownstreamPort
         port: 20
+        slot: 5
         width: 4
       - name: SSD 16
         type: DownstreamPort
         port: 22
+        slot: 4
         width: 4
       - name: SSD 17
         type: DownstreamPort
         port: 48
+        slot: 3
         width: 4

--- a/pkg/manager-fabric/config_default.yaml
+++ b/pkg/manager-fabric/config_default.yaml
@@ -52,42 +52,42 @@ switches:
       - name: SSD 0
         type: DownstreamPort
         port: 8
-        slot: 13
+        slot: 8
         width: 4
       - name: SSD 1
         type: DownstreamPort
         port: 10
-        slot: 14
+        slot: 7
         width: 4
       - name: SSD 2
         type: DownstreamPort
         port: 12
-        slot: 18
+        slot: 15
         width: 4
       - name: SSD 3
         type: DownstreamPort
         port: 14
-        slot: 17
+        slot: 16
         width: 4
       - name: SSD 4
         type: DownstreamPort
         port: 16
-        slot: 16
+        slot: 17
         width: 4
       - name: SSD 5
         type: DownstreamPort
         port: 18
-        slot: 15
+        slot: 18
         width: 4
       - name: SSD 6
         type: DownstreamPort
         port: 20
-        slot: 7
+        slot: 14
         width: 4
       - name: SSD 7
         type: DownstreamPort
         port: 22
-        slot: 8
+        slot: 13
         width: 4
       - name: SSD 8
         type: DownstreamPort
@@ -143,42 +143,42 @@ switches:
       - name: SSD 9
         type: DownstreamPort
         port: 8
-        slot: 11
+        slot: 4
         width: 4
       - name: SSD 10
         type: DownstreamPort
         port: 10
-        slot: 10
+        slot: 5
         width: 4
       - name: SSD 11
         type: DownstreamPort
         port: 12
-        slot: 9
+        slot: 6
         width: 4
       - name: SSD 12
         type: DownstreamPort
         port: 14
-        slot: 1
+        slot: 2
         width: 4
       - name: SSD 13
         type: DownstreamPort
         port: 16
-        slot: 2
+        slot: 1
         width: 4
       - name: SSD 14
         type: DownstreamPort
         port: 18
-        slot: 6
+        slot: 9
         width: 4
       - name: SSD 15
         type: DownstreamPort
         port: 20
-        slot: 5
+        slot: 10
         width: 4
       - name: SSD 16
         type: DownstreamPort
         port: 22
-        slot: 4
+        slot: 11
         width: 4
       - name: SSD 17
         type: DownstreamPort

--- a/pkg/manager-fabric/manager.go
+++ b/pkg/manager-fabric/manager.go
@@ -1532,3 +1532,29 @@ func (f *Fabric) FindDownstreamEndpoint(portId, functionId string) (string, erro
 
 	return fmt.Sprintf("/redfish/v1/Fabrics/%s/Endpoints/%s", f.id, ep.id), nil
 }
+
+func (f *Fabric) GetSwitchPort(switchId, portId string) (*Port, error) {
+	s := f.findSwitch(switchId)
+	if s == nil {
+		return nil, fmt.Errorf("failed to find switch: switchId: %s", switchId)
+	}
+	p := s.findPort(portId)
+	if p == nil {
+		return nil, fmt.Errorf("failed to find port: switchId: %s, portId: %s", switchId, portId)
+	}
+
+	return p, nil
+}
+
+func (f *Fabric) GetPortPartLocation(switchId, portId string) (*openapi.PartLocation, error) {
+	p, err := f.GetSwitchPort(switchId, portId)
+	if err != nil {
+		return nil, err
+	}
+
+	return &openapi.PartLocation{
+		ServiceLabel:         p.swtch.config.SlotPrefix,
+		LocationOrdinalValue: int64(p.config.Slot),
+		LocationType:         sf.SLOT_RV1100LT,
+	}, nil
+}

--- a/pkg/manager-nvme/manager.go
+++ b/pkg/manager-nvme/manager.go
@@ -988,6 +988,15 @@ func (mgr *Manager) StorageIdControllersControllerIdGet(storageId, controllerId 
 	model.FirmwareVersion = s.firmwareRevision
 	model.Model = s.modelNumber
 
+	// Retrieve the slot label and value for this storage controller
+	location, err := FabricController.GetPortPartLocation(s.switchId, s.portId)
+	if err != nil {
+		return ec.NewErrNotFound().WithError(err).WithCause(fmt.Sprintf("Storage Controller failed to retrieve part location: Storage: %s", storageId))
+	}
+	model.Location.PartLocation.ServiceLabel = location.ServiceLabel
+	model.Location.PartLocation.LocationOrdinalValue = location.LocationOrdinalValue
+	model.Location.PartLocation.LocationType = location.LocationType
+
 	model.Links.EndpointsodataCount = 1
 	model.Links.Endpoints = make([]sf.OdataV4IdRef, model.Links.EndpointsodataCount)
 	model.Links.Endpoints[0].OdataId = endpointId

--- a/pkg/rfsf/pkg/common/alias.go
+++ b/pkg/rfsf/pkg/common/alias.go
@@ -7,7 +7,7 @@
 
  * Author: Nate Roiger
  *
- * Copyright 2020 Hewlett Packard Enterprise Development LP
+ * Copyright 2020, 2022 Hewlett Packard Enterprise Development LP
  */
 
 package openapi
@@ -59,6 +59,9 @@ type ManagerActions = models.ManagerV1100Actions
 // OdataIdRef - A reference to a resource.
 type OdataIdRef = models.OdataV4IdRef
 
+// PartLocation - The part location within the placement.
+type PartLocation = models.ResourceV1100PartLocation
+
 // RedfishError - The error payload from a Redfish Service.
 type RedfishError = models.RedfishError
 
@@ -70,6 +73,9 @@ type ResourceBlock = models.ResourceBlockV133ResourceBlock
 
 // ResourceIdentifier - Any additional identifiers for a resource.
 type ResourceIdentifier = models.ResourceIdentifier
+
+// ResourceLocation - The location of a resource.
+type ResourceLocation = models.ResourceLocation
 
 // ResourcePowerState - Power state of a resource
 type ResourcePowerState = models.ResourcePowerState


### PR DESCRIPTION
This adds the ability to set the PartLocation from the Fabric Manager's config file. Each port defined in the config now supports `slot` and each switch can set a `slotPrefix` for the corresponding `slot`.

These values are stored in the Storage Controller's `PartLocation`.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>