### PR TITLE
Allow NnfStorageProfile to pass args for mkfs, lvm, lustre

### DIFF
--- a/pkg/manager-server/file_system_api.go
+++ b/pkg/manager-server/file_system_api.go
@@ -186,7 +186,7 @@ func (*FileSystem) run(cmd string) ([]byte, error) {
 	})
 }
 
-type FileSystemOemMkfsMountCmd struct {
+type FileSystemOemMkfsMount struct {
 	// The mkfs commandline, minus the "mkfs" command itself.
 	Mkfs string `json:"Mkfs,omitempty"`
 
@@ -194,7 +194,7 @@ type FileSystemOemMkfsMountCmd struct {
 	Mount []string `json:"Mount,omitempty"`
 }
 
-type FileSystemOemLvmCmd struct {
+type FileSystemOemLvm struct {
 	// The pvcreate commandline, minus the "pvcreate" command.
 	PvCreate string `json:"PvCreate,omitempty"`
 
@@ -205,7 +205,7 @@ type FileSystemOemLvmCmd struct {
 	LvCreate string `json:"LvCreate,omitempty"`
 }
 
-type FileSystemOemZfsCmd struct {
+type FileSystemOemZfs struct {
 	// The zpool create commandline, minus the "zpool create" command.
 	ZpoolCreate string `json:"ZpoolCreate,omitempty"`
 
@@ -231,9 +231,9 @@ type FileSystemOem struct {
 	Lustre FileSystemOemLustre `json:"Lustre,omitempty"`
 	Gfs2   FileSystemOemGfs2   `json:"Gfs2,omitempty"`
 
-	LvmCmd       FileSystemOemLvmCmd       `json:"LvmCmd,omitempty"`
-	MkfsMountCmd FileSystemOemMkfsMountCmd `json:"MkfsMountCmd,omitempty"`
-	ZfsCmd       FileSystemOemZfsCmd       `json:"ZfsCmd,omitempty"`
+	LvmCmd    FileSystemOemLvm       `json:"Lvm,omitempty"`
+	MkfsMount FileSystemOemMkfsMount `json:"MkfsMount,omitempty"`
+	ZfsCmd    FileSystemOemZfs       `json:"Zfs,omitempty"`
 }
 
 // File System Registry - Maintains a list of eligible file systems registered in the system.

--- a/pkg/manager-server/file_system_api.go
+++ b/pkg/manager-server/file_system_api.go
@@ -170,7 +170,7 @@ func (e *FileSystemError) Unwrap() error {
 }
 
 func (*FileSystem) run(cmd string) ([]byte, error) {
-	return logging.Cli.Trace(cmd, func(cmd string) ([]byte, error) {
+	return logging.Cli.Trace2(logging.LogToStdout, cmd, func(cmd string) ([]byte, error) {
 
 		fsError := FileSystemError{command: cmd}
 		shellCmd := exec.Command("bash", "-c", cmd)
@@ -186,18 +186,54 @@ func (*FileSystem) run(cmd string) ([]byte, error) {
 	})
 }
 
+type FileSystemOemMkfsMountCmd struct {
+	// The mkfs commandline, minus the "mkfs" command itself.
+	Mkfs string `json:"Mkfs,omitempty"`
+
+	// Arguments for the mount-utils library.
+	Mount []string `json:"Mount,omitempty"`
+}
+
+type FileSystemOemLvmCmd struct {
+	// The pvcreate commandline, minus the "pvcreate" command.
+	PvCreate string `json:"PvCreate,omitempty"`
+
+	// The vgcreate commandline, minus the "vgcreate" command.
+	VgCreate string `json:"VgCreate,omitempty"`
+
+	// The lvcreate commandline, minus the "lvcreate" command.
+	LvCreate string `json:"LvCreate,omitempty"`
+}
+
+type FileSystemOemZfsCmd struct {
+	// The zpool create commandline, minus the "zpool create" command.
+	ZpoolCreate string `json:"ZpoolCreate,omitempty"`
+
+	// For "zfs create", specify the args in the mkfs.lustre --mkfsoptions arg.
+}
+
+type FileSystemOemLustre struct {
+	MgsNode    string `json:"MgsNode,omitempty"`
+	TargetType string `json:"TargetType"`
+	Index      int    `json:"Index"`
+	BackFs     string `json:"BackFs"`
+}
+
+type FileSystemOemGfs2 struct {
+	ClusterName string `json:"ClusterName"`
+}
+
 // File System OEM defines the structure that is expected to be included inside a
 // Redfish / Swordfish FileSystemV122FileSystem
 type FileSystemOem struct {
-	Type string `json:"Type"`
-	Name string `json:"Name"`
-	// The following are used by Lustre, ignored for others.
-	MgsNode    string `json:"MgsNode,omitempty"`
-	TargetType string `json:"TargetType,omitempty"`
-	Index      int    `json:"Index,omitempty"`
-	BackFs     string `json:"BackFs,omitempty"`
-	// The following is used by GFS2, ignored for others.
-	ClusterName string `json:"ClusterName,omitempty"`
+	Type   string              `json:"Type"`
+	Name   string              `json:"Name"`
+	Lustre FileSystemOemLustre `json:"Lustre,omitempty"`
+	Gfs2   FileSystemOemGfs2   `json:"Gfs2,omitempty"`
+
+	LvmCmd       FileSystemOemLvmCmd       `json:"LvmCmd,omitempty"`
+	MkfsMountCmd FileSystemOemMkfsMountCmd `json:"MkfsMountCmd,omitempty"`
+	ZfsCmd       FileSystemOemZfsCmd       `json:"ZfsCmd,omitempty"`
 }
 
 // File System Registry - Maintains a list of eligible file systems registered in the system.

--- a/pkg/manager-server/file_system_gfs2.go
+++ b/pkg/manager-server/file_system_gfs2.go
@@ -29,8 +29,8 @@ import (
 type FileSystemGfs2 struct {
 	FileSystemLvm
 
-	Oem           FileSystemOemGfs2
-	MkfsMountArgs FileSystemOemMkfsMountCmd
+	Oem       FileSystemOemGfs2
+	MkfsMount FileSystemOemMkfsMount
 }
 
 func init() {
@@ -75,8 +75,8 @@ func (*FileSystemGfs2) New(oem FileSystemOem) (FileSystemApi, error) {
 			CmdArgs:    oem.LvmCmd,
 			shared:     true,
 		},
-		Oem:           oem.Gfs2,
-		MkfsMountArgs: oem.MkfsMountCmd,
+		Oem:       oem.Gfs2,
+		MkfsMount: oem.MkfsMount,
 	}, nil
 }
 
@@ -98,7 +98,7 @@ func (f *FileSystemGfs2) Create(devices []string, opts FileSystemOptions) error 
 		"$LOCK_SPACE":   f.Name(),
 		"$PROTOCOL":     "lock_dlm",
 	})
-	mkfsArgs := varHandler.ReplaceAll(f.MkfsMountArgs.Mkfs)
+	mkfsArgs := varHandler.ReplaceAll(f.MkfsMount.Mkfs)
 
 	if _, err := f.run(fmt.Sprintf("mkfs.gfs2 -O %s", mkfsArgs)); err != nil {
 		return err
@@ -108,5 +108,5 @@ func (f *FileSystemGfs2) Create(devices []string, opts FileSystemOptions) error 
 }
 
 func (f *FileSystemGfs2) Mount(mountpoint string) error {
-	return f.mount(f.devPath(), mountpoint, "", f.MkfsMountArgs.Mount)
+	return f.mount(f.devPath(), mountpoint, "", f.MkfsMount.Mount)
 }

--- a/pkg/manager-server/file_system_gfs2.go
+++ b/pkg/manager-server/file_system_gfs2.go
@@ -22,11 +22,15 @@ package server
 import (
 	"fmt"
 	"regexp"
+
+	"github.com/NearNodeFlash/nnf-ec/pkg/var_handler"
 )
 
 type FileSystemGfs2 struct {
 	FileSystemLvm
-	clusterName string
+
+	Oem           FileSystemOemGfs2
+	MkfsMountArgs FileSystemOemMkfsMountCmd
 }
 
 func init() {
@@ -50,7 +54,7 @@ func (*FileSystemGfs2) New(oem FileSystemOem) (FileSystemApi, error) {
 		return nil, fmt.Errorf("File Name '%s' overflows 16 character limit", oem.Name)
 	}
 
-	if len(oem.ClusterName) == 0 {
+	if len(oem.Gfs2.ClusterName) == 0 {
 		return nil, fmt.Errorf("Cluster Name not provided")
 	}
 
@@ -61,16 +65,18 @@ func (*FileSystemGfs2) New(oem FileSystemOem) (FileSystemApi, error) {
 		return nil, fmt.Errorf("File System Name '%s' is invalid. Must match pattern '%s'", oem.Name, exp.String())
 	}
 
-	if !exp.MatchString(oem.ClusterName) {
-		return nil, fmt.Errorf("Cluster Name '%s' is invalid. Must match pattern '%s'", oem.ClusterName, exp.String())
+	if !exp.MatchString(oem.Gfs2.ClusterName) {
+		return nil, fmt.Errorf("Cluster Name '%s' is invalid. Must match pattern '%s'", oem.Gfs2.ClusterName, exp.String())
 	}
 
 	return &FileSystemGfs2{
 		FileSystemLvm: FileSystemLvm{
 			FileSystem: FileSystem{name: oem.Name},
+			CmdArgs:    oem.LvmCmd,
 			shared:     true,
 		},
-		clusterName: oem.ClusterName,
+		Oem:           oem.Gfs2,
+		MkfsMountArgs: oem.MkfsMountCmd,
 	}, nil
 }
 
@@ -86,7 +92,15 @@ func (f *FileSystemGfs2) Create(devices []string, opts FileSystemOptions) error 
 		return err
 	}
 
-	if _, err := f.run(fmt.Sprintf("mkfs.gfs2 -O -j2 -p lock_dlm -t %s:%s %s", f.clusterName, f.Name(), f.FileSystemLvm.devPath())); err != nil {
+	varHandler := var_handler.NewVarHandler(map[string]string{
+		"$DEVICE":       f.FileSystemLvm.devPath(),
+		"$CLUSTER_NAME": f.Oem.ClusterName,
+		"$LOCK_SPACE":   f.Name(),
+		"$PROTOCOL":     "lock_dlm",
+	})
+	mkfsArgs := varHandler.ReplaceAll(f.MkfsMountArgs.Mkfs)
+
+	if _, err := f.run(fmt.Sprintf("mkfs.gfs2 -O %s", mkfsArgs)); err != nil {
 		return err
 	}
 
@@ -94,5 +108,5 @@ func (f *FileSystemGfs2) Create(devices []string, opts FileSystemOptions) error 
 }
 
 func (f *FileSystemGfs2) Mount(mountpoint string) error {
-	return f.mount(f.devPath(), mountpoint, "", nil)
+	return f.mount(f.devPath(), mountpoint, "", f.MkfsMountArgs.Mount)
 }

--- a/pkg/manager-server/file_system_lustre.go
+++ b/pkg/manager-server/file_system_lustre.go
@@ -24,35 +24,30 @@ import (
 	"os"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/NearNodeFlash/nnf-ec/pkg/var_handler"
 )
-
-type LustreTargetType string
 
 const (
-	TargetMGT    LustreTargetType = "MGT"
-	TargetMDT    LustreTargetType = "MDT"
-	TargetMGTMDT LustreTargetType = "MGTMDT"
-	TargetOST    LustreTargetType = "OST"
+	TargetMGT    string = "MGT"
+	TargetMDT    string = "MDT"
+	TargetMGTMDT string = "MGTMDT"
+	TargetOST    string = "OST"
 )
 
-var targetTypes = map[string]LustreTargetType{
+var targetTypes = map[string]string{
 	"MGT":    TargetMGT,
 	"MDT":    TargetMDT,
 	"MGTMDT": TargetMGTMDT,
 	"OST":    TargetOST,
 }
 
-type LustreBackFsType string
-
 const (
-	BackFsLdiskfs LustreBackFsType = "ldiskfs"
-	BackFsZfs     LustreBackFsType = "zfs"
+	BackFsLdiskfs string = "ldiskfs"
+	BackFsZfs     string = "zfs"
 )
 
-var backFsTypes = map[string]LustreBackFsType{
-	"ldiskfs": BackFsLdiskfs,
-	"zfs":     BackFsZfs,
+var backFsTypes = map[string]string{
+	"zfs": BackFsZfs,
 }
 
 func init() {
@@ -63,27 +58,25 @@ type FileSystemLustre struct {
 	// Satisfy FileSystemApi interface.
 	FileSystem
 
-	targetType LustreTargetType
-	mgsNode    string
-	index      int
-	backFs     LustreBackFsType
+	Oem           FileSystemOemLustre
+	MkfsMountArgs FileSystemOemMkfsMountCmd
+	ZfsArgs       FileSystemOemZfsCmd
 }
 
 func (*FileSystemLustre) New(oem FileSystemOem) (FileSystemApi, error) {
 	return &FileSystemLustre{
 		FileSystem: FileSystem{name: oem.Name},
-		mgsNode:    oem.MgsNode,
-		index:      oem.Index,
 		// TargetType and BackFs are already verified by IsType() below.
-		targetType: targetTypes[oem.TargetType],
-		backFs:     backFsTypes[oem.BackFs],
+		Oem:           oem.Lustre,
+		MkfsMountArgs: oem.MkfsMountCmd,
+		ZfsArgs:       oem.ZfsCmd,
 	}, nil
 }
 
 func (*FileSystemLustre) IsType(oem FileSystemOem) bool {
-	_, ok := targetTypes[oem.TargetType]
+	_, ok := targetTypes[oem.Lustre.TargetType]
 	if ok {
-		_, ok = backFsTypes[oem.BackFs]
+		_, ok = backFsTypes[oem.Lustre.BackFs]
 	}
 	return ok
 }
@@ -95,50 +88,55 @@ func (f *FileSystemLustre) Name() string   { return f.name }
 func (f *FileSystemLustre) Create(devices []string, options FileSystemOptions) error {
 
 	var err error
-	var backFs string
 	f.devices = devices
-	if f.backFs == BackFsZfs {
-		backFs = fmt.Sprintf("--backfstype=%s %s", f.backFs, f.zfsVolName())
+	if f.Oem.BackFs != BackFsZfs {
+		return fmt.Errorf("The backing FS must be ZFS")
 	}
+
 	devsStr := strings.Join(devices, " ")
 	if _, ok := os.LookupEnv("NNF_SUPPLIED_DEVICES"); ok {
 		// On non-NVMe.
 		devsStr = devices[0]
 	}
-	switch f.targetType {
-	case TargetMGT:
-		err = runCmd(f, fmt.Sprintf("mkfs.lustre --mgs %s %s", backFs, devsStr))
-	case TargetMDT:
-		err = runCmd(f, fmt.Sprintf("mkfs.lustre --mdt --fsname=%s --mgsnode=%s --index=%d %s %s", f.name, f.mgsNode, f.index, backFs, devsStr))
-	case TargetMGTMDT:
-		err = runCmd(f, fmt.Sprintf("mkfs.lustre --mgs --mdt --fsname=%s --index=%d %s %s", f.name, f.index, backFs, devsStr))
-	case TargetOST:
-		err = runCmd(f, fmt.Sprintf("mkfs.lustre --ost --fsname=%s --mgsnode=%s --index=%d %s %s", f.name, f.mgsNode, f.index, backFs, devsStr))
-	}
 
-	return err
-}
+	varHandler := var_handler.NewVarHandler(map[string]string{
+		"$DEVICE_NUM":  fmt.Sprintf("%d", len(devices)),
+		"$DEVICE_LIST": devsStr,
+		"$POOL_NAME":   f.zfsPoolName(),
+		"$VOL_NAME":    f.zfsVolName(), // <pool_name>/<dataset_name>
+		"$MGS_NID":     f.Oem.MgsNode,
+		"$INDEX":       fmt.Sprintf("%d", f.Oem.Index),
+		"$FS_NAME":     f.name,
+	})
 
-func runCmd(f *FileSystemLustre, cmd string) error {
-	out, err := f.run(cmd)
+	zpoolArgs := varHandler.ReplaceAll(f.ZfsArgs.ZpoolCreate)
+	zpoolCreate := fmt.Sprintf("zpool create %s", zpoolArgs)
+	_, err = f.run(zpoolCreate)
 	if err != nil {
-		log.Error(err, cmd)
+		return err
 	}
-	log.Info(cmd, " output ", string(out))
+
+	mkfsArgs := varHandler.ReplaceAll(f.MkfsMountArgs.Mkfs)
+	mkfsCmd := fmt.Sprintf("mkfs.lustre --backfstype=%s %s", f.Oem.BackFs, mkfsArgs)
+	_, err = f.run(mkfsCmd)
+	if err != nil {
+		// Destroy the zpool we created above.
+		_, _ = f.run(fmt.Sprintf("zpool destroy %s", f.zfsPoolName()))
+	}
 
 	return err
 }
 
 func (f *FileSystemLustre) Delete() error {
 	var err error
-	if f.backFs == BackFsZfs {
+	if f.Oem.BackFs == BackFsZfs {
 		zpool := f.zfsPoolName()
 		// Query the existence of the pool.
-		err = runCmd(f, fmt.Sprintf("zpool list %s", zpool))
+		_, err = f.run(fmt.Sprintf("zpool list %s", zpool))
 		if err != nil {
 			return err
 		}
-		err = runCmd(f, fmt.Sprintf("zpool destroy %s", zpool))
+		_, err = f.run(fmt.Sprintf("zpool destroy %s", zpool))
 		if err != nil {
 			return err
 		}
@@ -147,13 +145,13 @@ func (f *FileSystemLustre) Delete() error {
 	if _, ok := os.LookupEnv("NNF_SUPPLIED_DEVICES"); ok {
 		// On non-NVMe, wipe so devices can be reused.
 		var devName string = f.devices[0]
-		err = runCmd(f, fmt.Sprintf("wipefs --all %s", devName))
+		_, err = f.run(fmt.Sprintf("wipefs --all %s", devName))
 		if err != nil {
 			return err
 		}
 	}
 	// Inform the OS of partition table changes.
-	err = runCmd(f, "partprobe")
+	_, err = f.run("partprobe")
 	if err != nil {
 		return err
 	}
@@ -163,14 +161,14 @@ func (f *FileSystemLustre) Delete() error {
 
 func (f *FileSystemLustre) Mount(mountpoint string) error {
 
-	var devName string 
-	if f.backFs == BackFsZfs {
+	var devName string
+	if f.Oem.BackFs == BackFsZfs {
 		devName = f.zfsVolName()
 	} else {
 		devName = f.devices[0]
 	}
 
-	return f.mount(devName, mountpoint, "lustre", nil)
+	return f.mount(devName, mountpoint, "lustre", f.MkfsMountArgs.Mount)
 }
 
 func (f *FileSystemLustre) GenerateRecoveryData() map[string]string {
@@ -182,7 +180,7 @@ func (f *FileSystemLustre) LoadRecoveryData(map[string]string) {
 }
 
 func (f *FileSystemLustre) zfsTargType() string {
-	return strings.ToLower(string(f.targetType))
+	return strings.ToLower(string(f.Oem.TargetType))
 }
 
 func (f *FileSystemLustre) zfsPoolName() string {
@@ -190,5 +188,5 @@ func (f *FileSystemLustre) zfsPoolName() string {
 }
 
 func (f *FileSystemLustre) zfsVolName() string {
-	return fmt.Sprintf("%s/%s%d", f.zfsPoolName(), f.zfsTargType(), f.index)
+	return fmt.Sprintf("%s/%s%d", f.zfsPoolName(), f.zfsTargType(), f.Oem.Index)
 }

--- a/pkg/manager-server/file_system_lvm.go
+++ b/pkg/manager-server/file_system_lvm.go
@@ -39,7 +39,7 @@ type FileSystemLvm struct {
 	lvName  string
 	vgName  string
 	shared  bool
-	CmdArgs FileSystemOemLvmCmd
+	CmdArgs FileSystemOemLvm
 }
 
 func init() {
@@ -110,6 +110,9 @@ func (f *FileSystemLvm) Create(devices []string, opts FileSystemOptions) error {
 		"$LV_NAME":     f.lvName,
 		"$VG_NAME":     f.vgName,
 	})
+	if err := varHandler.ListToVars("$DEVICE_LIST", "$DEVICE"); err != nil {
+		return fmt.Errorf("invalid internal device list: %w", err)
+	}
 
 	// Create the physical volumes.
 	for _, device := range devices {

--- a/pkg/manager-server/file_system_lvm.go
+++ b/pkg/manager-server/file_system_lvm.go
@@ -24,6 +24,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/NearNodeFlash/nnf-ec/pkg/var_handler"
 )
 
 const (
@@ -34,9 +36,10 @@ const (
 type FileSystemLvm struct {
 	// Satisfy FileSystemApi interface.
 	FileSystem
-	lvName string
-	vgName string
-	shared bool
+	lvName  string
+	vgName  string
+	shared  bool
+	CmdArgs FileSystemOemLvmCmd
 }
 
 func init() {
@@ -46,6 +49,7 @@ func init() {
 func (*FileSystemLvm) New(oem FileSystemOem) (FileSystemApi, error) {
 	return &FileSystemLvm{
 		FileSystem: FileSystem{name: oem.Name},
+		CmdArgs:    oem.LvmCmd,
 		shared:     false,
 	}, nil
 }
@@ -100,12 +104,22 @@ func (f *FileSystemLvm) Create(devices []string, opts FileSystemOptions) error {
 		return nil
 	}
 
+	varHandler := var_handler.NewVarHandler(map[string]string{
+		"$DEVICE_NUM":  fmt.Sprintf("%d", len(devices)),
+		"$DEVICE_LIST": strings.Join(devices, " "),
+		"$LV_NAME":     f.lvName,
+		"$VG_NAME":     f.vgName,
+	})
+
 	// Create the physical volumes.
 	for _, device := range devices {
-		if _, err := f.run(fmt.Sprintf("pvcreate %s", device)); err != nil {
+		varHandler.VarMap["$DEVICE"] = device
+		pvArgs := varHandler.ReplaceAll(f.CmdArgs.PvCreate)
+		if _, err := f.run(fmt.Sprintf("pvcreate %s", pvArgs)); err != nil {
 			return err
 		}
 	}
+	delete(varHandler.VarMap, "$DEVICE")
 
 	// Check if we are creating a shared volume group and prepend the necessary flag
 	shared := ""
@@ -113,7 +127,8 @@ func (f *FileSystemLvm) Create(devices []string, opts FileSystemOptions) error {
 		shared = "--shared"
 	}
 
-	if _, err := f.run(fmt.Sprintf("vgcreate %s %s %s", shared, f.vgName, strings.Join(devices, " "))); err != nil {
+	vgArgs := varHandler.ReplaceAll(f.CmdArgs.VgCreate)
+	if _, err := f.run(fmt.Sprintf("vgcreate %s %s", shared, vgArgs)); err != nil {
 		return err
 	}
 
@@ -147,7 +162,8 @@ func (f *FileSystemLvm) Create(devices []string, opts FileSystemOptions) error {
 		zeroOpt = "--yes"
 	}
 
-	if _, err := f.run(fmt.Sprintf("lvcreate %s -l 100%%VG --stripes %d --stripesize=32KiB --name %s %s", zeroOpt, len(devices), f.lvName, f.vgName)); err != nil {
+	lvArgs := varHandler.ReplaceAll(f.CmdArgs.LvCreate)
+	if _, err := f.run(fmt.Sprintf("lvcreate %s %s", zeroOpt, lvArgs)); err != nil {
 		return err
 	}
 

--- a/pkg/manager-server/file_system_xfs.go
+++ b/pkg/manager-server/file_system_xfs.go
@@ -19,11 +19,17 @@
 
 package server
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/NearNodeFlash/nnf-ec/pkg/var_handler"
+)
 
 // FileSystemXfs establishes an XFS file system on an underlying LVM logical volume.
 type FileSystemXfs struct {
 	FileSystemLvm
+
+	MkfsMountArgs FileSystemOemMkfsMountCmd
 }
 
 func init() {
@@ -34,7 +40,9 @@ func (*FileSystemXfs) New(oem FileSystemOem) (FileSystemApi, error) {
 	return &FileSystemXfs{
 		FileSystemLvm: FileSystemLvm{
 			FileSystem: FileSystem{name: oem.Name},
+			CmdArgs:    oem.LvmCmd,
 		},
+		MkfsMountArgs: oem.MkfsMountCmd,
 	}, nil
 }
 
@@ -49,7 +57,12 @@ func (f *FileSystemXfs) Create(devices []string, opts FileSystemOptions) error {
 		return err
 	}
 
-	if _, err := f.run(fmt.Sprintf("mkfs.xfs %s", f.FileSystemLvm.devPath())); err != nil {
+	varHandler := var_handler.NewVarHandler(map[string]string{
+		"$DEVICE": f.FileSystemLvm.devPath(),
+	})
+	mkfsArgs := varHandler.ReplaceAll(f.MkfsMountArgs.Mkfs)
+
+	if _, err := f.run(fmt.Sprintf("mkfs.xfs %s", mkfsArgs)); err != nil {
 		return err
 	}
 
@@ -57,6 +70,5 @@ func (f *FileSystemXfs) Create(devices []string, opts FileSystemOptions) error {
 }
 
 func (f *FileSystemXfs) Mount(mountpoint string) error {
-	return f.mount(f.devPath(), mountpoint, "", nil)
+	return f.mount(f.devPath(), mountpoint, "", f.MkfsMountArgs.Mount)
 }
-

--- a/pkg/manager-server/file_system_xfs.go
+++ b/pkg/manager-server/file_system_xfs.go
@@ -29,7 +29,7 @@ import (
 type FileSystemXfs struct {
 	FileSystemLvm
 
-	MkfsMountArgs FileSystemOemMkfsMountCmd
+	MkfsMount FileSystemOemMkfsMount
 }
 
 func init() {
@@ -42,7 +42,7 @@ func (*FileSystemXfs) New(oem FileSystemOem) (FileSystemApi, error) {
 			FileSystem: FileSystem{name: oem.Name},
 			CmdArgs:    oem.LvmCmd,
 		},
-		MkfsMountArgs: oem.MkfsMountCmd,
+		MkfsMount: oem.MkfsMount,
 	}, nil
 }
 
@@ -60,7 +60,7 @@ func (f *FileSystemXfs) Create(devices []string, opts FileSystemOptions) error {
 	varHandler := var_handler.NewVarHandler(map[string]string{
 		"$DEVICE": f.FileSystemLvm.devPath(),
 	})
-	mkfsArgs := varHandler.ReplaceAll(f.MkfsMountArgs.Mkfs)
+	mkfsArgs := varHandler.ReplaceAll(f.MkfsMount.Mkfs)
 
 	if _, err := f.run(fmt.Sprintf("mkfs.xfs %s", mkfsArgs)); err != nil {
 		return err
@@ -70,5 +70,5 @@ func (f *FileSystemXfs) Create(devices []string, opts FileSystemOptions) error {
 }
 
 func (f *FileSystemXfs) Mount(mountpoint string) error {
-	return f.mount(f.devPath(), mountpoint, "", f.MkfsMountArgs.Mount)
+	return f.mount(f.devPath(), mountpoint, "", f.MkfsMount.Mount)
 }

--- a/pkg/var_handler/var_handler.go
+++ b/pkg/var_handler/var_handler.go
@@ -19,7 +19,10 @@
 
 package var_handler
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 type VarHandler struct {
 	VarMap map[string]string
@@ -29,6 +32,20 @@ func NewVarHandler(vars map[string]string) *VarHandler {
 	v := &VarHandler{}
 	v.VarMap = vars
 	return v
+}
+
+// ListToVars splits the value of one of its variables, and creates a new
+// indexed variable for each of the items in the split.
+func (v *VarHandler) ListToVars(listVarName, newVarPrefix string) error {
+	theList, ok := v.VarMap[listVarName]
+	if !ok {
+		return fmt.Errorf("Unable to find the variable named %s", listVarName)
+	}
+
+	for i, val := range strings.Split(theList, " ") {
+		v.VarMap[fmt.Sprintf("%s%d", newVarPrefix, i+1)] = val
+	}
+	return nil
 }
 
 func (v *VarHandler) ReplaceAll(s string) string {

--- a/pkg/var_handler/var_handler.go
+++ b/pkg/var_handler/var_handler.go
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package var_handler
+
+import "strings"
+
+type VarHandler struct {
+	VarMap map[string]string
+}
+
+func NewVarHandler(vars map[string]string) *VarHandler {
+	v := &VarHandler{}
+	v.VarMap = vars
+	return v
+}
+
+func (v *VarHandler) ReplaceAll(s string) string {
+	for key, value := range v.VarMap {
+		s = strings.ReplaceAll(s, key, value)
+	}
+	return s
+}

--- a/pkg/var_handler/var_handler_test.go
+++ b/pkg/var_handler/var_handler_test.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package var_handler
+
+import (
+	"testing"
+)
+
+func TestVarHandler(t *testing.T) {
+	varMap := map[string]string{
+		"$BIGDOG":  "Jules",
+		"$GREYDOG": "Henri",
+	}
+
+	v := NewVarHandler(varMap)
+	// Add a late-arriving variable.
+	v.VarMap["$FAVTOY"] = "rope"
+
+	in1 := "The big dog is $BIGDOG, the little dog is $GREYDOG. $BIGDOG and $GREYDOG are best friends and their favorite toy is the $FAVTOY."
+	want1 := "The big dog is Jules, the little dog is Henri. Jules and Henri are best friends and their favorite toy is the rope."
+	out1 := v.ReplaceAll(in1)
+	if out1 != want1 {
+		t.Errorf("Did not get the desired result.  Got (%s)", out1)
+	}
+
+	// Change a variable.
+	v.VarMap["$FAVTOY"] = "ball"
+	in2 := "$BIGDOG likes the $FAVTOY."
+	want2 := "Jules likes the ball."
+	out2 := v.ReplaceAll(in2)
+	if out2 != want2 {
+		t.Errorf("Did not get desired result.  Got (%s)", out2)
+	}
+
+	// Delete a variable.
+	delete(v.VarMap, "$FAVTOY")
+	in3 := "$GREYDOG's favorite toy was the $FAVTOY."
+	want3 := "Henri's favorite toy was the $FAVTOY."
+	out3 := v.ReplaceAll(in3)
+	if out3 != want3 {
+		t.Errorf("Did not get desired result.  Got (%s)", out3)
+	}
+}

--- a/pkg/var_handler/var_handler_test.go
+++ b/pkg/var_handler/var_handler_test.go
@@ -57,4 +57,17 @@ func TestVarHandler(t *testing.T) {
 	if out3 != want3 {
 		t.Errorf("Did not get desired result.  Got (%s)", out3)
 	}
+
+	// Add a list to turn into variables.
+	v.VarMap["$DEVICE_LIST"] = "/dev/nvme0n1 /dev/nvme1n1 /dev/nvme0n2 /dev/nvme1n2"
+	if err := v.ListToVars("$DEVICE_LIST", "$DEVICE"); err != nil {
+		t.Errorf("Did not split list: %v", err)
+	} else {
+		in4 := "zpool mirror $DEVICE1 $DEVICE2 mirror $DEVICE3 $DEVICE4"
+		want4 := "zpool mirror /dev/nvme0n1 /dev/nvme1n1 mirror /dev/nvme0n2 /dev/nvme1n2"
+		out4 := v.ReplaceAll(in4)
+		if out4 != want4 {
+			t.Errorf("Did not get desired result. Got (%s)", out4)
+		}
+	}
 }


### PR DESCRIPTION
All FS commandlines are passed in from the nnf-sos layer.

Introduce variables into the commandlines, to allow the EC layer to insert dynamic values.

Let the NNF logs see the FS commands and their results.

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>