### PR TITLE
RABSW-1062: Read PCI Configuration Space Registers tool

### DIFF
--- a/tools/pci.sh
+++ b/tools/pci.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Copyright 2022 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+usage() {
+    cat << EOF
+Shows the hexadecimal dump of the whole PCI configuration space for the provide switchtec device identifer. The output
+can be saved to a file and then parsed using 'lspci -F <file>'.
+
+Usage: $0 SWITCH PDFID [COUNT=64]
+
+  SWITCH must be a valid Switchtec device (ex: /dev/switchtec0)
+  PDFID must be the physical device function ID
+  COUNT is the number of 32-bit register reads (default 64)
+
+Example:
+  pci.sh /dev/switchtec0 0x1800
+
+  pci.sh /dev/switchtec0 0x1800 > temp.txt && lspci -F temp.txt -vvv
+EOF
+}
+
+if [ $# -lt 2 ]; then
+    usage
+    exit 1
+fi
+
+SWITCH=$1
+PDFID=$2
+
+COUNT=${3:-64}
+
+IFS=$'\n' read -ra LINES -d $'\0' <<< "$(switchtec fabric ep-csr-read "${SWITCH}" --pdfid="${PDFID}" --addr=0 --bytes=4 --count="${COUNT}" --print=hex)"
+
+echo -n "00:00.0 UNKNOWN NVME DEVICE"
+
+for INDEX in "${!LINES[@]}"
+do
+    
+    if [ $((INDEX%4)) == 0 ]; then
+        printf "\n"
+        printf "%02x: " $((INDEX*4))
+    fi
+
+    DATA=$(echo "${LINES[$INDEX]}" | cut -d " " -f 3)
+    echo -n "${DATA:8:2} ${DATA:6:2} ${DATA:4:2} ${DATA:2:2} "
+
+done
+
+echo ""


### PR DESCRIPTION
Tool to read the PCI Configuration Space Registers. We can then confirm the PCI configuration as optimal

```
$pci.sh /dev/switchtec0 0x1800 > temp.txt && lspci -F temp.txt -vvvv
00:00.0 Non-Volatile memory controller: KIOXIA Corporation Device 0014 (rev 01) (prog-if 02 [NVM Express])
        Subsystem: KIOXIA Corporation Device 0052
        Control: I/O- Mem+ BusMaster+ SpecCycle- MemWINV- VGASnoop- ParErr- Stepping- SERR- FastB2B- DisINTx-
        Status: Cap+ 66MHz- UDF- FastB2B- ParErr- DEVSEL=fast >TAbort- <TAbort- <MAbort- >SERR- <PERR- INTx-
        Latency: 0
        Interrupt: pin A routed to IRQ 255
        Region 0: Memory at 41c00000 (64-bit, non-prefetchable)
        Capabilities: [40] Power Management version 3
                Flags: PMEClk- DSI- D1- D2- AuxCurrent=0mA PME(D0-,D1-,D2-,D3hot-,D3cold-)
                Status: D0 NoSoftRst+ PME-Enable- DSel=0 DScale=0 PME-
        Capabilities: [70] Express (v2) Endpoint, MSI 00
                DevCap: MaxPayload 1024 bytes, PhantFunc 0, Latency L0s unlimited, L1 unlimited
                        ExtTag+ AttnBtn- AttnInd- PwrInd- RBE+ FLReset+ SlotPowerLimit 0.000W
                DevCtl: CorrErr- NonFatalErr- FatalErr- UnsupReq-
                        RlxdOrd+ ExtTag+ PhantFunc- AuxPwr- NoSnoop+ FLReset-
                        MaxPayload 256 bytes, MaxReadReq 512 bytes
                DevSta: CorrErr- NonFatalErr- FatalErr- UnsupReq- AuxPwr- TransPend-
                LnkCap: Port #0, Speed 32GT/s, Width x4, ASPM not supported
                        ClockPM- Surprise- LLActRep- BwNot- ASPMOptComp+
                LnkCtl: ASPM Disabled; RCB 64 bytes, Disabled- CommClk-
                        ExtSynch- ClockPM- AutWidDis- BWInt- AutBWInt-
                LnkSta: Speed 16GT/s (downgraded), Width x4 (ok)
                        TrErr- Train- SlotClk+ DLActive- BWMgmt- ABWMgmt-
                DevCap2: Completion Timeout: Range ABCD, TimeoutDis+ NROPrPrP- LTR-
                         10BitTagComp+ 10BitTagReq- OBFF Not Supported, ExtFmt- EETLPPrefix-
                         EmergencyPowerReduction Not Supported, EmergencyPowerReductionInit-
                         FRS- TPHComp- ExtTPHComp-
                DevCtl2: Completion Timeout: 50us to 50ms, TimeoutDis- LTR- OBFF Disabled,
                         AtomicOpsCtl: ReqEn-
                LnkCap2: Supported Link Speeds: 2.5-32GT/s, Crosslink- Retimer+ 2Retimers+ DRS-
                LnkCtl2: Target Link Speed: 32GT/s, EnterCompliance- SpeedDis-
                         Transmit Margin: Normal Operating Range, EnterModifiedCompliance- ComplianceSOS-
                         Compliance De-emphasis: -6dB
                LnkSta2: Current De-emphasis Level: -6dB, EqualizationComplete+ EqualizationPhase1+
                         EqualizationPhase2+ EqualizationPhase3+ LinkEqualizationRequest-
                         Retimer- 2Retimers- CrosslinkRes: Upstream Port
        Capabilities: [b0] MSI-X: Enable- Count=129 Masked-
                Vector table: BAR=0 offset=00005200
                PBA: BAR=0 offset=0000d600
        Capabilities: [d0] Vital Product Data
                Not readable
```
Signed-off-by: Nate Roiger <nate.roiger@hpe.com>