### PR TITLE
Storage Pools: Remove abandoned namespaces

### DIFF
--- a/pkg/manager-nnf/allocation_policy.go
+++ b/pkg/manager-nnf/allocation_policy.go
@@ -34,7 +34,7 @@ import (
 type AllocationPolicy interface {
 	Initialize(capacityBytes uint64) error
 	CheckCapacity() error
-	Allocate(guid uuid.UUID) ([]ProvidingVolume, error)
+	Allocate(guid uuid.UUID) ([]nvme.ProvidingVolume, error)
 }
 
 // AllocationPolicyType -
@@ -174,12 +174,12 @@ func (p *SpareAllocationPolicy) CheckCapacity() error {
 	return nil
 }
 
-func (p *SpareAllocationPolicy) Allocate(pid uuid.UUID) ([]ProvidingVolume, error) {
+func (p *SpareAllocationPolicy) Allocate(pid uuid.UUID) ([]nvme.ProvidingVolume, error) {
 
 	perStorageCapacityBytes := p.capacityBytes / uint64(len(p.storage))
 	remainingCapacityBytes := p.capacityBytes
 
-	volumes := []ProvidingVolume{}
+	volumes := []nvme.ProvidingVolume{}
 	for idx, storage := range p.storage {
 
 		capacityBytes := perStorageCapacityBytes
@@ -198,7 +198,7 @@ func (p *SpareAllocationPolicy) Allocate(pid uuid.UUID) ([]ProvidingVolume, erro
 		}
 
 		remainingCapacityBytes = remainingCapacityBytes - volume.GetCapaityBytes()
-		volumes = append(volumes, ProvidingVolume{storage: storage, volumeId: volume.Id()})
+		volumes = append(volumes, nvme.ProvidingVolume{Storage: storage, VolumeId: volume.Id()})
 	}
 
 	return volumes, nil

--- a/pkg/manager-nnf/manager.go
+++ b/pkg/manager-nnf/manager.go
@@ -555,10 +555,6 @@ func (s *StorageService) EventHandler(e event.Event) error {
 		// Remove any namespaces that are not part of a Storage Pool
 		log.Infof("Storage Service: Removing Volumes that are not allocated as part of a Storage Pool")
 		s.cleanupVolumes()
-		// if err := s.cleanupVolumes(); err != nil {
-		// 	log.WithError(err).Errorf("Failed to cleanup volumes")
-		// 	return err
-		// }
 	}
 
 	return nil

--- a/pkg/manager-nnf/storage_group.go
+++ b/pkg/manager-nnf/storage_group.go
@@ -126,7 +126,7 @@ func (sg *StorageGroup) Rollback(state uint32) error {
 		}
 
 		for _, pv := range sp.providingVolumes {
-			if err := nvme.DetachController(pv.storage.FindVolume(pv.volumeId), sg.endpoint.controllerId); err != nil {
+			if err := nvme.DetachController(pv.Storage.FindVolume(pv.VolumeId), sg.endpoint.controllerId); err != nil {
 				return err
 			}
 		}
@@ -140,7 +140,7 @@ func (sg *StorageGroup) Rollback(state uint32) error {
 		}
 
 		for _, pv := range sp.providingVolumes {
-			if err := nvme.AttachController(pv.storage.FindVolume(pv.volumeId), sg.endpoint.controllerId); err != nil {
+			if err := nvme.AttachController(pv.Storage.FindVolume(pv.VolumeId), sg.endpoint.controllerId); err != nil {
 				return err
 			}
 		}
@@ -206,7 +206,7 @@ func (rh *storageGroupRecoveryReplyHandler) Done() (bool, error) {
 
 		sp := rh.storageService.findStoragePool(sg.storagePoolId)
 		for _, pv := range sp.providingVolumes {
-			if err := nvme.DetachController(pv.storage.FindVolume(pv.volumeId), sg.endpoint.controllerId); err != nil {
+			if err := nvme.DetachController(pv.Storage.FindVolume(pv.VolumeId), sg.endpoint.controllerId); err != nil {
 				return false, err
 			}
 		}

--- a/pkg/manager-nvme/manager.go
+++ b/pkg/manager-nvme/manager.go
@@ -432,10 +432,13 @@ func (s *Storage) purge() error {
 	return nil
 }
 
+// Delete all the volumes on this storage device except for the volumes that we want to keep
 func (s *Storage) purgeVolumes(volIdsToKeep []string) error {
 	if s.device == nil {
 		return fmt.Errorf("Storage %s has no device", s.id)
 	}
+
+	var volIdsToDelete []string
 
 vol_loop:
 	for _, vol := range s.volumes {
@@ -444,9 +447,12 @@ vol_loop:
 				continue vol_loop
 			}
 		}
+		volIdsToDelete = append(volIdsToDelete, vol.id)
+	}
 
-		log.Infof("Storage %s Volume ID %s is being removed", s.id, vol.id)
-		if err := s.deleteVolume(vol.id); err != nil {
+	for _, volId := range volIdsToDelete {
+		log.Infof("Storage %s Volume ID %s is being removed", s.id, volId)
+		if err := s.deleteVolume(volId); err != nil {
 			return err
 		}
 	}

--- a/pkg/manager-nvme/manager.go
+++ b/pkg/manager-nvme/manager.go
@@ -143,6 +143,10 @@ type Volume struct {
 
 	storage *Storage
 }
+type PersistentVolumeInfo struct {
+	SerialNumber string                   `json:"SerialNumber"`
+	NamespaceId  nvme.NamespaceIdentifier `json:"NamespaceId"`
+}
 
 // TODO: We may want to put this manager under a resource block
 //   /​redfish/​v1/​ResourceBlocks/​{ResourceBlockId} // <- Rabbit
@@ -189,6 +193,29 @@ func findStorageVolume(storageId, volumeId string) (*Storage, *Volume) {
 
 func findStoragePool(storageId, storagePoolId string) (*Storage, *interface{}) {
 	return nil, nil
+}
+
+func CleanupVolumes(volumesToKeep []PersistentVolumeInfo) error {
+	// For each storage device, build a list of namespaces to keep and then remove everything else
+	for _, storage := range mgr.storage {
+		if !storage.IsEnabled() {
+			continue
+		}
+
+		var namespacesToKeep []nvme.NamespaceIdentifier
+		for _, keepVolume := range volumesToKeep {
+			if keepVolume.SerialNumber == storage.serialNumber {
+				namespacesToKeep = append(namespacesToKeep, keepVolume.NamespaceId)
+			}
+		}
+
+		if err := storage.CleanupNamespaces(namespacesToKeep); err != nil {
+			// TODO return error here or just move to the next storage device?
+			return fmt.Errorf("Cleanup Volumes: Failed to remove abandoned namespaces on storage %s: %v", storage.id, err)
+		}
+	}
+
+	return nil
 }
 
 func (m *Manager) fmt(format string, a ...interface{}) string {
@@ -390,12 +417,45 @@ func (s *Storage) initialize() error {
 }
 
 func (s *Storage) purge() error {
+	if s.device == nil {
+		return fmt.Errorf("Storage %s has no device", s.id)
+	}
+
 	namespaces, err := s.device.ListNamespaces(0)
 	if err != nil {
 		return err
 	}
 
 	for _, nsid := range namespaces {
+		if err := s.device.DeleteNamespace(nsid); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *Storage) purgeExcept(namespaceIdsToKeep []nvme.NamespaceIdentifier) error {
+	if s.device == nil {
+		return fmt.Errorf("Storage %s has no device", s.id)
+	}
+
+	namespaces, err := s.device.ListNamespaces(0)
+	if err != nil {
+		return err
+	}
+
+namespace_loop:
+	for _, nsid := range namespaces {
+		// Skip over any namespaces that we want to keep
+		for _, ns := range namespaceIdsToKeep {
+			if nsid == ns {
+				log.Infof("Keeping namespace ID %d on storage %s", nsid, s.id)
+				continue namespace_loop
+			}
+		}
+
+		log.Infof("Removing namespace ID %d from storage %s", nsid, s.id)
 		if err := s.device.DeleteNamespace(nsid); err != nil {
 			return err
 		}
@@ -561,6 +621,10 @@ func (s *Storage) recoverVolumes() error {
 	}
 
 	return nil
+}
+
+func (s *Storage) CleanupNamespaces(namespacesToKeep []nvme.NamespaceIdentifier) error {
+	return s.purgeExcept(namespacesToKeep)
 }
 
 func (s *Storage) findVolume(volumeId string) *Volume {

--- a/pkg/persistent/kvstore.go
+++ b/pkg/persistent/kvstore.go
@@ -74,7 +74,7 @@ func (s *Store) Replay() error {
 					return err
 				}
 
-				delete, err := s.runReply(r, key, value)
+				delete, err := s.runReplay(r, key, value)
 				if err != nil {
 					return err
 				}
@@ -174,7 +174,7 @@ type Registry interface {
 	NewReplay(id string) ReplayHandler
 }
 
-func (s *Store) runReply(registry Registry, key string, data []byte) (delete bool, err error) {
+func (s *Store) runReplay(registry Registry, key string, data []byte) (delete bool, err error) {
 	id := string(key[len(registry.Prefix()):])
 	it := newIterator(data)
 	replay := registry.NewReplay(string(id))


### PR DESCRIPTION
After all storage pool replays are complete, remove any namespaces that are not associated with the storage pools.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>