### PR TITLE
RABSW-1083: Set owner and group after mkfs

### DIFF
--- a/pkg/manager-server/file_system_api.go
+++ b/pkg/manager-server/file_system_api.go
@@ -31,6 +31,11 @@ import (
 	"github.com/NearNodeFlash/nnf-ec/pkg/logging"
 )
 
+const (
+	UserID = "userID"
+	GroupID = "groupID"
+)
+
 type FileSystemControllerApi interface {
 	NewFileSystem(oem FileSystemOem) (FileSystemApi, error)
 }

--- a/pkg/manager-server/file_system_gfs2.go
+++ b/pkg/manager-server/file_system_gfs2.go
@@ -22,7 +22,6 @@ package server
 import (
 	"fmt"
 	"regexp"
-	"os"
 
 	"github.com/NearNodeFlash/nnf-ec/pkg/var_handler"
 )
@@ -105,33 +104,7 @@ func (f *FileSystemGfs2) Create(devices []string, opts FileSystemOptions) (err e
 		return err
 	}
 
-	userID := 0
-	if _, exists := opts[UserID]; exists {
-		userID = opts[UserID].(int)
-	}
-
-	groupID := 0
-	if _, exists := opts[GroupID]; exists {
-		groupID = opts[GroupID].(int)
-	}
-
-	mountpath := "/mnt/nnf/client/" + f.name
-	if err := f.Mount(mountpath); err != nil {
-		return err
-	}
-
-	defer func() {
-		unmountErr := f.Unmount(mountpath)
-		if err == nil {
-			err = unmountErr
-		}
-	}()
-
-	if err := os.Chown(mountpath, userID, groupID); err != nil {
-		return err
-	}
-
-	return nil
+	return setFileSystemPermissions(f, opts)
 }
 
 func (f *FileSystemGfs2) Mount(mountpoint string) error {

--- a/pkg/manager-server/file_system_gfs2.go
+++ b/pkg/manager-server/file_system_gfs2.go
@@ -120,7 +120,12 @@ func (f *FileSystemGfs2) Create(devices []string, opts FileSystemOptions) (err e
 		return err
 	}
 
-	defer func() { err = f.Unmount(mountpath) }()
+	defer func() {
+		unmountErr := f.Unmount(mountpath)
+		if err == nil {
+			err = unmountErr
+		}
+	}()
 
 	if err := os.Chown(mountpath, userID, groupID); err != nil {
 		return err

--- a/pkg/manager-server/file_system_xfs.go
+++ b/pkg/manager-server/file_system_xfs.go
@@ -21,7 +21,6 @@ package server
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/NearNodeFlash/nnf-ec/pkg/var_handler"
 )
@@ -67,33 +66,7 @@ func (f *FileSystemXfs) Create(devices []string, opts FileSystemOptions) (err er
 		return err
 	}
 
-	userID := 0
-	if _, exists := opts[UserID]; exists {
-		userID = opts[UserID].(int)
-	}
-
-	groupID := 0
-	if _, exists := opts[GroupID]; exists {
-		groupID = opts[GroupID].(int)
-	}
-
-	mountpath := "/mnt/nnf/client/" + f.name
-	if err := f.Mount(mountpath); err != nil {
-		return err
-	}
-
-	defer func() {
-		unmountErr := f.Unmount(mountpath)
-		if err == nil {
-			err = unmountErr
-		}
-	}()
-
-	if err := os.Chown(mountpath, userID, groupID); err != nil {
-		return err
-	}
-
-	return nil
+	return setFileSystemPermissions(f, opts)
 }
 
 func (f *FileSystemXfs) Mount(mountpoint string) error {

--- a/pkg/manager-server/file_system_xfs.go
+++ b/pkg/manager-server/file_system_xfs.go
@@ -21,8 +21,14 @@ package server
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/NearNodeFlash/nnf-ec/pkg/var_handler"
+)
+
+const (
+	UserID = "userID"
+	GroupID = "groupID"
 )
 
 // FileSystemXfs establishes an XFS file system on an underlying LVM logical volume.
@@ -52,7 +58,7 @@ func (*FileSystemXfs) IsMockable() bool              { return false }
 func (*FileSystemXfs) Type() string   { return "xfs" }
 func (f *FileSystemXfs) Name() string { return f.name }
 
-func (f *FileSystemXfs) Create(devices []string, opts FileSystemOptions) error {
+func (f *FileSystemXfs) Create(devices []string, opts FileSystemOptions) (err error) {
 	if err := f.FileSystemLvm.Create(devices, opts); err != nil {
 		return err
 	}
@@ -63,6 +69,27 @@ func (f *FileSystemXfs) Create(devices []string, opts FileSystemOptions) error {
 	mkfsArgs := varHandler.ReplaceAll(f.MkfsMount.Mkfs)
 
 	if _, err := f.run(fmt.Sprintf("mkfs.xfs %s", mkfsArgs)); err != nil {
+		return err
+	}
+
+	userID := 0
+	if _, exists := opts[UserID]; exists {
+		userID = opts[UserID].(int)
+	}
+
+	groupID := 0
+	if _, exists := opts[GroupID]; exists {
+		groupID = opts[GroupID].(int)
+	}
+
+	mountpath := "/mnt/nnf/client/" + f.name
+	if err := f.Mount(mountpath); err != nil {
+		return err
+	}
+
+	defer func() { err = f.Unmount(mountpath) }()
+
+	if err := os.Chown(mountpath, userID, groupID); err != nil {
 		return err
 	}
 

--- a/pkg/manager-server/file_system_xfs.go
+++ b/pkg/manager-server/file_system_xfs.go
@@ -26,11 +26,6 @@ import (
 	"github.com/NearNodeFlash/nnf-ec/pkg/var_handler"
 )
 
-const (
-	UserID = "userID"
-	GroupID = "groupID"
-)
-
 // FileSystemXfs establishes an XFS file system on an underlying LVM logical volume.
 type FileSystemXfs struct {
 	FileSystemLvm
@@ -87,7 +82,12 @@ func (f *FileSystemXfs) Create(devices []string, opts FileSystemOptions) (err er
 		return err
 	}
 
-	defer func() { err = f.Unmount(mountpath) }()
+	defer func() {
+		unmountErr := f.Unmount(mountpath)
+		if err == nil {
+			err = unmountErr
+		}
+	}()
 
 	if err := os.Chown(mountpath, userID, groupID); err != nil {
 		return err


### PR DESCRIPTION
Mount the file system and set the owner/group to the desired values. This is only necessary for XFS and gfs2 file systems.

Signed-off-by: Matt Richerson <matthew.richerson@Matts-MacBook-Pro.local>