### PR TITLE
NVMe Manager: Unallocated Bytes can get out of sync with drive data

### DIFF
--- a/pkg/manager-nvme/nvme_api.go
+++ b/pkg/manager-nvme/nvme_api.go
@@ -53,7 +53,7 @@ type NvmeDeviceApi interface {
 	ListNamespaces(controllerId uint16) ([]nvme.NamespaceIdentifier, error)
 	ListAttachedControllers(namespaceId nvme.NamespaceIdentifier) ([]uint16, error)
 
-	CreateNamespace(capacityBytes uint64, sectorSizeBytes uint64, sectorSizeIndex uint8) (nvme.NamespaceIdentifier, nvme.NamespaceGloballyUniqueIdentifier, error)
+	CreateNamespace(sizeInSectors uint64, sectorSizeIndex uint8) (nvme.NamespaceIdentifier, nvme.NamespaceGloballyUniqueIdentifier, error)
 	DeleteNamespace(namespaceId nvme.NamespaceIdentifier) error
 
 	FormatNamespace(namespaceID nvme.NamespaceIdentifier) error

--- a/pkg/manager-nvme/nvme_cli.go
+++ b/pkg/manager-nvme/nvme_cli.go
@@ -220,13 +220,12 @@ func (d *cliDevice) ListAttachedControllers(namespaceId nvme.NamespaceIdentifier
 	return controllerIds, nil
 }
 
-func (d *cliDevice) CreateNamespace(capacityBytes uint64, sectorSizeBytes uint64, sectorSizeIndex uint8) (nvme.NamespaceIdentifier, nvme.NamespaceGloballyUniqueIdentifier, error) {
+func (d *cliDevice) CreateNamespace(sizeInSectors uint64, sectorSizeIndex uint8) (nvme.NamespaceIdentifier, nvme.NamespaceGloballyUniqueIdentifier, error) {
 	// Example Command
-	//    # nvme create-ns /dev/nvme2 --nsze=468843606 --ncap=468843606 --nmic=1 --block-size=4096
+	//    # nvme create-ns /dev/nvme2 --nsze=468843606 --ncap=468843606 --flbas=3 --nmic=1 
 	//    create-ns: Success, created nsid:1
 
-	sizeInSectors := capacityBytes / sectorSizeBytes
-	rsp, err := d.run(fmt.Sprintf("create-ns %s --nsze=%d --ncap=%d --block-size=%d --nmic=1", d.dev(), sizeInSectors, sizeInSectors, sectorSizeBytes))
+	rsp, err := d.run(fmt.Sprintf("create-ns %s --nsze=%d --ncap=%d --flbas=%d --nmic=1", d.dev(), sizeInSectors, sizeInSectors, sectorSizeIndex))
 	if err != nil {
 		return 0, nvme.NamespaceGloballyUniqueIdentifier{}, err
 	}

--- a/pkg/manager-nvme/nvme_device.go
+++ b/pkg/manager-nvme/nvme_device.go
@@ -156,17 +156,11 @@ func (d *nvmeDevice) GetNamespace(namespaceId nvme.NamespaceIdentifier) (*nvme.I
 }
 
 // CreateNamespace -
-func (d *nvmeDevice) CreateNamespace(capacityBytes uint64, sectorSizeBytes uint64, sectorSizeIndex uint8) (nvme.NamespaceIdentifier, nvme.NamespaceGloballyUniqueIdentifier, error) {
-
-	roundUpToMultiple := func(n, m uint64) uint64 {
-		return ((n + m - 1) / m) * m
-	}
-
-	size := roundUpToMultiple(capacityBytes/sectorSizeBytes, sectorSizeBytes)
+func (d *nvmeDevice) CreateNamespace(sizeInSectors uint64, sectorSizeIndex uint8) (nvme.NamespaceIdentifier, nvme.NamespaceGloballyUniqueIdentifier, error) {
 
 	id, err := d.dev.CreateNamespace(
-		size,            // Size in Data Size Units (usually 4096)
-		size,            // Capacity in Data Size Units (usually 4096),
+		sizeInSectors,   // Size in Data Size Units (usually 4096)
+		sizeInSectors,   // Capacity in Data Size Units (usually 4096),
 		sectorSizeIndex, // LBA Format Index (see above)
 		0,               // Data Protection Capaiblities (none)
 		0x1,             // Capabilities (sharing = 1b)

--- a/pkg/manager-nvme/nvme_direct_device.go
+++ b/pkg/manager-nvme/nvme_direct_device.go
@@ -114,8 +114,8 @@ func (d *nvmeDirectDevice) ListAttachedControllers(namespaceId nvme.NamespaceIde
 	return d.cliDevice.ListAttachedControllers(namespaceId)
 }
 
-func (d *nvmeDirectDevice) CreateNamespace(capacityBytes uint64, sectorSizeBytes uint64, sectorSizeIndex uint8) (nvme.NamespaceIdentifier, nvme.NamespaceGloballyUniqueIdentifier, error) {
-	return d.cliDevice.CreateNamespace(capacityBytes, sectorSizeBytes, sectorSizeIndex)
+func (d *nvmeDirectDevice) CreateNamespace(sizeInSectors uint64, sectorSizeIndex uint8) (nvme.NamespaceIdentifier, nvme.NamespaceGloballyUniqueIdentifier, error) {
+	return d.cliDevice.CreateNamespace(sizeInSectors, sectorSizeIndex)
 }
 
 func (d *nvmeDirectDevice) DeleteNamespace(namespaceId nvme.NamespaceIdentifier) error {

--- a/pkg/manager-nvme/nvme_mock.go
+++ b/pkg/manager-nvme/nvme_mock.go
@@ -300,8 +300,13 @@ func (d *mockDevice) ListAttachedControllers(namespaceId nvme.NamespaceIdentifie
 }
 
 // CreateNamespace -
-func (d *mockDevice) CreateNamespace(capacityBytes uint64, sectorSizeBytes uint64, sectorSizeIndex uint8) (nvme.NamespaceIdentifier, nvme.NamespaceGloballyUniqueIdentifier, error) {
+func (d *mockDevice) CreateNamespace(sizeInSectors uint64, sectorSizeIndex uint8) (nvme.NamespaceIdentifier, nvme.NamespaceGloballyUniqueIdentifier, error) {
 
+	if (sizeInSectors % mockSectorSizeInBytes) != 0 {
+		return 0, nvme.NamespaceGloballyUniqueIdentifier{}, fmt.Errorf("Size is not a multiple of sector size: Size: %d Sector Size: %d", sizeInSectors, mockSectorSizeInBytes)
+	}
+
+	capacityBytes := sizeInSectors * mockSectorSizeInBytes
 	if capacityBytes > (d.capacity - d.allocatedCapacity) {
 		return 0, nvme.NamespaceGloballyUniqueIdentifier{}, fmt.Errorf("Insufficient capacity: Requested: %d Available: %d", capacityBytes, (d.capacity - d.allocatedCapacity))
 	}
@@ -312,7 +317,7 @@ func (d *mockDevice) CreateNamespace(capacityBytes uint64, sectorSizeBytes uint6
 	}
 
 	ns.id = nvme.NamespaceIdentifier(ns.idx)
-	ns.capacity = capacityBytes / mockSectorSizeInBytes
+	ns.capacity = capacityBytes
 	ns.guid = [16]byte{
 		0, 0, 0, 0,
 		0, 0, 0, 0,

--- a/pkg/manager-nvme/nvme_mock.go
+++ b/pkg/manager-nvme/nvme_mock.go
@@ -302,10 +302,6 @@ func (d *mockDevice) ListAttachedControllers(namespaceId nvme.NamespaceIdentifie
 // CreateNamespace -
 func (d *mockDevice) CreateNamespace(sizeInSectors uint64, sectorSizeIndex uint8) (nvme.NamespaceIdentifier, nvme.NamespaceGloballyUniqueIdentifier, error) {
 
-	if (sizeInSectors % mockSectorSizeInBytes) != 0 {
-		return 0, nvme.NamespaceGloballyUniqueIdentifier{}, fmt.Errorf("Size is not a multiple of sector size: Size: %d Sector Size: %d", sizeInSectors, mockSectorSizeInBytes)
-	}
-
 	capacityBytes := sizeInSectors * mockSectorSizeInBytes
 	if capacityBytes > (d.capacity - d.allocatedCapacity) {
 		return 0, nvme.NamespaceGloballyUniqueIdentifier{}, fmt.Errorf("Insufficient capacity: Requested: %d Available: %d", capacityBytes, (d.capacity - d.allocatedCapacity))


### PR DESCRIPTION
NVMe Manager was not tracking the unallocated byte count during namespace creation or deletion, instead relying on various GETs of redfish endpoints to call `refreshCapacity()`. This change removes the `refreshCapacity()` method and tracks the unallocated capacity whenever a namespace is created or deleted.

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>