### PR TITLE
Ensure 'rabbit-s.sh enable-logging' works with Linux distros

### DIFF
--- a/tools/rabbit-s.sh
+++ b/tools/rabbit-s.sh
@@ -71,7 +71,7 @@ case $CMD in
         declare -a DEVICES=("pax0 /dev/ttyS9" "pax1 /dev/ttyS11")
         for DEVICE in "${DEVICES[@]}"
         do
-            PAX=$(echo $DEVICE | cut -w -f1)
+            PAX=$(echo $DEVICE | cut -d' ' -f1)
 
             echo "Enabling Logging on $PAX"
             $SSHPASS ssh -T root@$SYSTEM <<-EOF


### PR DESCRIPTION
The '-w' option, to set the delimiter to spaces and tabs, is an extension only available on Darwin.

We only need spaces so revert to the -d option

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>