### PR TITLE
Final Rabbit hardware does not have slot prefix 'J' on the front panel

### DIFF
--- a/pkg/manager-fabric/config_default.yaml
+++ b/pkg/manager-fabric/config_default.yaml
@@ -7,7 +7,6 @@ switches:
     metadata:
       name: PAX 0
     pciGen: 4
-    slotPrefix: J
     ports:
       - name: Interswitch Fabric
         type: InterswitchPort
@@ -98,7 +97,6 @@ switches:
     metadata:
       name: PAX 1
     pciGen: 4
-    slotPrefix: J
     ports:
       - name: Interswitch Fabric
         type: InterswitchPort


### PR DESCRIPTION
Signed-off-by: Nate Thornton <nate.thornton@hpe.com>