### PR TITLE
Fix for failed unmount when IsMountPoint() returns ErrNotExist

### DIFF
--- a/pkg/manager-server/file_system_api.go
+++ b/pkg/manager-server/file_system_api.go
@@ -21,7 +21,9 @@ package server
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 
@@ -129,6 +131,10 @@ func (f *FileSystem) Unmount(mountpoint string) error {
 	mounter := mount.New("")
 	mounted, err := mounter.IsMountPoint(mountpoint)
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+
 		return err
 	}
 
@@ -272,7 +278,7 @@ func (r *fileSystemRegistry) NewFileSystem(oem FileSystemOem) (FileSystemApi, er
 
 func setFileSystemPermissions(f FileSystemApi, opts FileSystemOptions) (err error) {
 	const (
-		UserID = "userID"
+		UserID  = "userID"
 		GroupID = "groupID"
 	)
 


### PR DESCRIPTION
When Unmount() is called, the IsMountPoint() check returns (false, ErrNotExist) when the target path doesn't exist. We want to ignore ErrNotExist, but return all other errors

It's still unclear _how_ we got into this state, but this should ensure the File Share delete doesn't get stuck.

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>