### PR TITLE
Fix for the spare allocation policy logic

### DIFF
--- a/pkg/manager-nnf/allocation_policy.go
+++ b/pkg/manager-nnf/allocation_policy.go
@@ -114,6 +114,9 @@ func NewAllocationPolicy(config AllocationConfig, oem map[string]interface{}) Al
 
 /* ------------------------------ Spare Allocation Policy --------------------- */
 
+// Required number of drives for the Spare Allocation Policy
+const SpareAllocationPolicyRequiredDriveCount = 16
+
 type SpareAllocationPolicy struct {
 	compliance     AllocationComplianceType
 	storage        []*nvme.Storage
@@ -135,7 +138,7 @@ func (p *SpareAllocationPolicy) Initialize(capacityBytes uint64) error {
 		return !!!(storage[i].UnallocatedBytes() < storage[j].UnallocatedBytes())
 	})
 
-	count := 16
+	count := SpareAllocationPolicyRequiredDriveCount
 	if len(storage) < count {
 		count = len(storage)
 	}
@@ -162,8 +165,8 @@ func (p *SpareAllocationPolicy) CheckCapacity() error {
 
 	if p.compliance != RelaxedAllocationComplianceType {
 
-		if len(p.storage) != 16 {
-			return fmt.Errorf("Insufficient drive count. Available %d", len(p.storage))
+		if len(p.storage) != SpareAllocationPolicyRequiredDriveCount {
+			return fmt.Errorf("Insufficient drive count. Required: %d Available: %d", SpareAllocationPolicyRequiredDriveCount, len(p.storage))
 		}
 
 		roundUpToMultiple := func(n, m uint64) uint64 { // Round 'n' up to a multiple of 'm'
@@ -171,7 +174,9 @@ func (p *SpareAllocationPolicy) CheckCapacity() error {
 		}
 
 		// Validate each drive can contribute sufficient capacity towards the entire pool.
-		driveCapacityBytes := roundUpToMultiple(roundUpToMultiple(p.capacityBytes, 16) / 16, 4096)
+		poolCapacityBytes := roundUpToMultiple(p.capacityBytes, SpareAllocationPolicyRequiredDriveCount)
+		driveCapacityBytes := roundUpToMultiple(poolCapacityBytes/SpareAllocationPolicyRequiredDriveCount, 4096)
+
 		for _, s := range p.storage {
 			if driveCapacityBytes > s.UnallocatedBytes() {
 				return fmt.Errorf("Insufficient drive capacity available. Requested: %d Available: %d", driveCapacityBytes, s.UnallocatedBytes())


### PR DESCRIPTION
The spare allocation policy was incorrectly considering drives with 0 bytes to spare. As long as the cumulative spare bytes amongst all drives is available, the policy check would pass and we'd try to allocate 1/16th on all the drives, even drives with 0 bytes to spare. The fix is to only consider storage devices that are both enabled and have spare bytes.

Another bug is present in the un-relaxed allocation mode, where we would only consider allocations that are a multiple of the drive count. This doesn't take into consideration that all drives should present 1/16th of the request capacity to keep things balanced.

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>