### PR TITLE
NVMe Mock Device has incorrect capacity

### DIFF
--- a/pkg/manager-nvme/nvme_mock.go
+++ b/pkg/manager-nvme/nvme_mock.go
@@ -129,10 +129,9 @@ type mockDevice struct {
 }
 
 type mockController struct {
-	id       uint16
-	online   bool
-	capacity uint64
-	//allocatedCapacity uint64
+	id          uint16
+	online      bool
+	capacity    uint64
 	vqresources uint32
 	viresources uint32
 }

--- a/pkg/manager-nvme/nvme_mock_persistence.go
+++ b/pkg/manager-nvme/nvme_mock_persistence.go
@@ -24,8 +24,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/NearNodeFlash/nnf-ec/pkg/persistent"
 	"github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/nvme"
+	"github.com/NearNodeFlash/nnf-ec/pkg/persistent"
 )
 
 // NVME Mock Persistence - Handles the various persistent aspects of an NVMe device, specifically namespaces
@@ -89,14 +89,14 @@ func (mgr *MockNvmePersistenceManager) load(dev *mockDevice) error {
 				}
 
 				ns.id = nvme.NamespaceIdentifier(namespace.NamespaceId)
-				ns.capacity = namespace.Capacity
+				ns.capacityInBytes = namespace.Capacity
 				ns.guid = namespace.GUID
 
 				for _, ctrlId := range namespace.controllerIds {
 					ns.attachedControllers[ctrlId] = &dev.controllers[ctrlId]
 				}
 
-				dev.allocatedCapacity += ns.capacity
+				dev.allocatedCapacity += ns.capacityInBytes
 			}
 
 			return nil
@@ -124,7 +124,7 @@ func (mgr *MockNvmePersistenceManager) new(dev *mockDevice) error {
 }
 
 func (mgr *MockNvmePersistenceManager) recordCreateNamespace(dev *mockDevice, ns *mockNamespace) {
-	ledger, err := mgr.store.OpenKey(mockNvmePersistenceRegistryPrefix+dev.id())
+	ledger, err := mgr.store.OpenKey(mockNvmePersistenceRegistryPrefix + dev.id())
 	if err != nil {
 		panic(err)
 	}
@@ -132,7 +132,7 @@ func (mgr *MockNvmePersistenceManager) recordCreateNamespace(dev *mockDevice, ns
 	data, _ := json.Marshal(&mockNvmeDevicePersistentNamespaceData{
 		NamespaceId: uint32(ns.id),
 		GUID:        ns.guid,
-		Capacity:    ns.capacity,
+		Capacity:    ns.capacityInBytes,
 	})
 
 	if err := ledger.Log(mockNvmePersistenceNamespaceCreate, data); err != nil {
@@ -143,7 +143,7 @@ func (mgr *MockNvmePersistenceManager) recordCreateNamespace(dev *mockDevice, ns
 }
 
 func (mgr *MockNvmePersistenceManager) recordDeleteNamespace(dev *mockDevice, ns *mockNamespace) {
-	ledger, err := mgr.store.OpenKey(mockNvmePersistenceRegistryPrefix+dev.id())
+	ledger, err := mgr.store.OpenKey(mockNvmePersistenceRegistryPrefix + dev.id())
 	if err != nil {
 		panic(err)
 	}
@@ -162,7 +162,7 @@ func (mgr *MockNvmePersistenceManager) recordDeleteNamespace(dev *mockDevice, ns
 }
 
 func (mgr *MockNvmePersistenceManager) recordAttachController(dev *mockDevice, ns *mockNamespace, ctrlId uint16) {
-	ledger, err := mgr.store.OpenKey(mockNvmePersistenceRegistryPrefix+dev.id())
+	ledger, err := mgr.store.OpenKey(mockNvmePersistenceRegistryPrefix + dev.id())
 	if err != nil {
 		panic(err)
 	}
@@ -180,7 +180,7 @@ func (mgr *MockNvmePersistenceManager) recordAttachController(dev *mockDevice, n
 }
 
 func (mgr *MockNvmePersistenceManager) recordDetachController(dev *mockDevice, ns *mockNamespace, ctrlId uint16) {
-	ledger, err := mgr.store.OpenKey(mockNvmePersistenceRegistryPrefix+dev.id())
+	ledger, err := mgr.store.OpenKey(mockNvmePersistenceRegistryPrefix + dev.id())
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/manager-nvme/nvme_mock_persistence.go
+++ b/pkg/manager-nvme/nvme_mock_persistence.go
@@ -78,7 +78,7 @@ func (mgr *MockNvmePersistenceManager) close() error {
 // all the NVMe Namespaces with the attached Controllers.
 func (mgr *MockNvmePersistenceManager) load(dev *mockDevice) error {
 
-	dev.allocatedCapacity = 0
+	dev.allocatedCapacityInBytes = 0
 	for replayIdx := range mgr.replays {
 		replay := &mgr.replays[replayIdx]
 		if dev.id() == replay.id {
@@ -96,7 +96,7 @@ func (mgr *MockNvmePersistenceManager) load(dev *mockDevice) error {
 					ns.attachedControllers[ctrlId] = &dev.controllers[ctrlId]
 				}
 
-				dev.allocatedCapacity += ns.capacityInBytes
+				dev.allocatedCapacityInBytes += ns.capacityInBytes
 			}
 
 			return nil


### PR DESCRIPTION
For mock NVMe devices, I goofed in #43 when using the capacity-in-bytes vs capacity-in-sectors

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>