### PR TITLE
RABSW-587: Support for retryable errors. Don't hang file share create

### DIFF
--- a/pkg/ec/error.go
+++ b/pkg/ec/error.go
@@ -40,11 +40,14 @@ func NewControllerError(sc int) *ControllerError {
 
 func (e *ControllerError) Error() string {
 	errorString := fmt.Sprintf("Error %d: %s", e.statusCode, http.StatusText(e.statusCode))
-	if len(e.cause) != 0 {
-		errorString += fmt.Sprintf(", Cause: %s", e.cause)
+	if e.IsRetryable() {
+		errorString += fmt.Sprintf(", Retry-Delay: %ds", e.retryDelayInSeconds)
 	}
 	if len(e.resourceType) != 0 {
 		errorString += fmt.Sprintf(", Resource: %s", e.resourceType)
+	}
+	if len(e.cause) != 0 {
+		errorString += fmt.Sprintf(", Cause: %s", e.cause)
 	}
 	if e.err != nil {
 		errorString += fmt.Sprintf(", Internal Error: %s", e.err)


### PR DESCRIPTION
- Adds a retryable error type to ec errors
- Adds retry delay to ec errors
- Improves error string
- Use the above when creating a file share instead of indefinitely hanging (RABSW-587)

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>