### PR TITLE
RABSW-1081: Add index to zpool name

### DIFF
--- a/pkg/manager-server/file_system_lustre.go
+++ b/pkg/manager-server/file_system_lustre.go
@@ -187,7 +187,7 @@ func (f *FileSystemLustre) zfsTargType() string {
 }
 
 func (f *FileSystemLustre) zfsPoolName() string {
-	return fmt.Sprintf("%s-%spool", f.name, f.zfsTargType())
+	return fmt.Sprintf("%s-%spool-%d", f.name, f.zfsTargType(), f.Oem.Index)
 }
 
 func (f *FileSystemLustre) zfsVolName() string {


### PR DESCRIPTION
If there are multiple of the same Lustre target on a single server, the zpool name collides.

Signed-off-by: Matt Richerson <matthew.richerson@Matts-MacBook-Pro.local>