### PR TITLE
Fixes / Improvements for file system handling

### DIFF
--- a/pkg/manager-nnf/file_system.go
+++ b/pkg/manager-nnf/file_system.go
@@ -180,7 +180,7 @@ func (rh *fileSystemRecoveryReplyHandler) Metadata(data []byte) error {
 		return err
 	}
 
-	fsApi, err := server.FileSystemController.NewFileSystem(metadata.FileSystemOem)
+	fsApi, err := server.FileSystemController.NewFileSystem(&metadata.FileSystemOem)
 	if err != nil {
 		return fmt.Errorf("File System %s Replay: Failed to create api %s", rh.fileSystemId, err)
 	}

--- a/pkg/manager-nnf/manager.go
+++ b/pkg/manager-nnf/manager.go
@@ -1202,7 +1202,7 @@ func (*StorageService) StorageServiceIdFileSystemsPost(storageServiceId string, 
 		return ec.NewErrBadRequest().WithResourceType(FileSystemOdataType).WithError(err).WithEvent(msgreg.MalformedJSONBase())
 	}
 
-	fsApi, err := server.FileSystemController.NewFileSystem(oem)
+	fsApi, err := server.FileSystemController.NewFileSystem(&oem)
 	if err != nil {
 		return ec.NewErrNotAcceptable().WithResourceType(FileSystemOdataType).WithError(err).WithCause("File system '%s' failed to allocate").WithEvent(msgreg.InternalErrorBase())
 	}

--- a/pkg/manager-nnf/router.go
+++ b/pkg/manager-nnf/router.go
@@ -246,7 +246,7 @@ func (r *DefaultApiRouter) Routes() ec.Routes {
 		},
 		{
 			Name:        "RedfishV1StorageServicesStorageServiceIdFileSystemsFileSystemsIdExportedFileSharesExportedFileSharesIdDelete",
-			Method:      ec.GET_METHOD,
+			Method:      ec.DELETE_METHOD,
 			Path:        "/redfish/v1/StorageServices/{StorageServiceId}/FileSystems/{FileSystemsId}/ExportedFileShares/{ExportedFileSharesId}",
 			HandlerFunc: s.RedfishV1StorageServicesStorageServiceIdFileSystemsFileSystemsIdExportedFileSharesExportedFileSharesIdDelete,
 		},

--- a/pkg/manager-remote/manager.go
+++ b/pkg/manager-remote/manager.go
@@ -419,7 +419,7 @@ func (s *ServerStorageService) StorageServiceIdFileSystemsPost(storageServiceId 
 		return ec.NewErrBadRequest().WithError(err)
 	}
 
-	api, err := server.FileSystemController.NewFileSystem(oem)
+	api, err := server.FileSystemController.NewFileSystem(&oem)
 	if err != nil {
 		return ec.NewErrBadRequest().WithError(err)
 	}

--- a/pkg/manager-server/file_system_api.go
+++ b/pkg/manager-server/file_system_api.go
@@ -200,6 +200,22 @@ type FileSystemOemMkfsMount struct {
 	Mount []string `json:"Mount,omitempty"`
 }
 
+func (oem FileSystemOemMkfsMount) IsZero() bool {
+	return len(oem.Mkfs) == 0 && len(oem.Mount) == 0
+}
+
+func (oem FileSystemOemMkfsMount) XfsDefaults() FileSystemOemMkfsMount {
+	return FileSystemOemMkfsMount{
+		Mkfs: "$DEVICE",
+	}
+}
+
+func (oem FileSystemOemMkfsMount) Gfs2Defaults() FileSystemOemMkfsMount {
+	return FileSystemOemMkfsMount{
+		Mkfs: "-j2 -p $PROTOCOL -t $CLUSTER_NAME:$LOCK_SPACE $DEVICE",
+	}
+}
+
 type FileSystemOemLvm struct {
 	// The pvcreate commandline, minus the "pvcreate" command.
 	PvCreate string `json:"PvCreate,omitempty"`
@@ -209,6 +225,18 @@ type FileSystemOemLvm struct {
 
 	// The lvcreate commandline, minus the "lvcreate" command.
 	LvCreate string `json:"LvCreate,omitempty"`
+}
+
+func (oem FileSystemOemLvm) IsZero() bool {
+	return len(oem.PvCreate) == 0 && len(oem.VgCreate) == 0 && len(oem.LvCreate) == 0
+}
+
+func (FileSystemOemLvm) Defaults() FileSystemOemLvm {
+	return FileSystemOemLvm{
+		PvCreate: "$DEVICE",
+		VgCreate: "$VG_NAME $DEVICE_LIST",
+		LvCreate: "-l 100%VG --stripes $DEVICE_NUM --stripesize=32KiB --name $LV_NAME $VG_NAME",
+	}
 }
 
 type FileSystemOemZfs struct {
@@ -229,11 +257,22 @@ type FileSystemOemGfs2 struct {
 	ClusterName string `json:"ClusterName"`
 }
 
+func (oem FileSystemOemGfs2) IsZero() bool {
+	return len(oem.ClusterName) == 0
+}
+
+func (FileSystemOemGfs2) Defaults() FileSystemOemGfs2 {
+	return FileSystemOemGfs2{
+		ClusterName: "$CLUSTER_NAME",
+	}
+}
+
 // File System OEM defines the structure that is expected to be included inside a
 // Redfish / Swordfish FileSystemV122FileSystem
 type FileSystemOem struct {
-	Type   string              `json:"Type"`
-	Name   string              `json:"Name"`
+	Type string `json:"Type"`
+	Name string `json:"Name"`
+
 	Lustre FileSystemOemLustre `json:"Lustre,omitempty"`
 	Gfs2   FileSystemOemGfs2   `json:"Gfs2,omitempty"`
 

--- a/pkg/manager-server/file_system_gfs2.go
+++ b/pkg/manager-server/file_system_gfs2.go
@@ -69,6 +69,18 @@ func (*FileSystemGfs2) New(oem FileSystemOem) (FileSystemApi, error) {
 		return nil, fmt.Errorf("Cluster Name '%s' is invalid. Must match pattern '%s'", oem.Gfs2.ClusterName, exp.String())
 	}
 
+	if oem.LvmCmd.IsZero() {
+		oem.LvmCmd = oem.LvmCmd.Defaults()
+	}
+
+	if oem.Gfs2.IsZero() {
+		oem.Gfs2 = oem.Gfs2.Defaults()
+	}
+
+	if oem.MkfsMount.IsZero() {
+		oem.MkfsMount = oem.MkfsMount.Gfs2Defaults()
+	}
+
 	return &FileSystemGfs2{
 		FileSystemLvm: FileSystemLvm{
 			FileSystem: FileSystem{name: oem.Name},

--- a/pkg/manager-server/file_system_gfs2.go
+++ b/pkg/manager-server/file_system_gfs2.go
@@ -69,18 +69,6 @@ func (*FileSystemGfs2) New(oem FileSystemOem) (FileSystemApi, error) {
 		return nil, fmt.Errorf("Cluster Name '%s' is invalid. Must match pattern '%s'", oem.Gfs2.ClusterName, exp.String())
 	}
 
-	if oem.LvmCmd.IsZero() {
-		oem.LvmCmd = oem.LvmCmd.Defaults()
-	}
-
-	if oem.Gfs2.IsZero() {
-		oem.Gfs2 = oem.Gfs2.Defaults()
-	}
-
-	if oem.MkfsMount.IsZero() {
-		oem.MkfsMount = oem.MkfsMount.Gfs2Defaults()
-	}
-
 	return &FileSystemGfs2{
 		FileSystemLvm: FileSystemLvm{
 			FileSystem: FileSystem{name: oem.Name},
@@ -92,11 +80,15 @@ func (*FileSystemGfs2) New(oem FileSystemOem) (FileSystemApi, error) {
 	}, nil
 }
 
-func (*FileSystemGfs2) IsType(oem FileSystemOem) bool { return oem.Type == "gfs2" }
-func (*FileSystemGfs2) IsMockable() bool              { return false }
-func (*FileSystemGfs2) Type() string                  { return "gfs2" }
+func (*FileSystemGfs2) IsType(oem *FileSystemOem) bool { return oem.Type == "gfs2" }
+func (*FileSystemGfs2) IsMockable() bool               { return false }
+func (*FileSystemGfs2) Type() string                   { return "gfs2" }
 
 func (f *FileSystemGfs2) Name() string { return f.name }
+
+func (*FileSystemGfs2) MkfsDefault() string {
+	return "-j2 -p $PROTOCOL -t $CLUSTER_NAME:$LOCK_SPACE $DEVICE"
+}
 
 func (f *FileSystemGfs2) Create(devices []string, opts FileSystemOptions) (err error) {
 

--- a/pkg/manager-server/file_system_lustre.go
+++ b/pkg/manager-server/file_system_lustre.go
@@ -58,6 +58,8 @@ type FileSystemLustre struct {
 	// Satisfy FileSystemApi interface.
 	FileSystem
 
+	TargetType string
+
 	Oem       FileSystemOemLustre
 	MkfsMount FileSystemOemMkfsMount
 	ZfsArgs   FileSystemOemZfs
@@ -66,14 +68,14 @@ type FileSystemLustre struct {
 func (*FileSystemLustre) New(oem FileSystemOem) (FileSystemApi, error) {
 	return &FileSystemLustre{
 		FileSystem: FileSystem{name: oem.Name},
-		// TargetType and BackFs are already verified by IsType() below.
-		Oem:       oem.Lustre,
-		MkfsMount: oem.MkfsMount,
-		ZfsArgs:   oem.ZfsCmd,
+		TargetType: targetTypes[oem.Lustre.TargetType],
+		Oem:        oem.Lustre,
+		MkfsMount:  oem.MkfsMount,
+		ZfsArgs:    oem.ZfsCmd,
 	}, nil
 }
 
-func (*FileSystemLustre) IsType(oem FileSystemOem) bool {
+func (*FileSystemLustre) IsType(oem *FileSystemOem) bool {
 	_, ok := targetTypes[oem.Lustre.TargetType]
 	if ok {
 		_, ok = backFsTypes[oem.Lustre.BackFs]
@@ -83,7 +85,17 @@ func (*FileSystemLustre) IsType(oem FileSystemOem) bool {
 
 func (*FileSystemLustre) IsMockable() bool { return false }
 func (*FileSystemLustre) Type() string     { return "lustre" }
-func (f *FileSystemLustre) Name() string   { return f.name }
+
+func (f *FileSystemLustre) Name() string { return f.name }
+
+func (f *FileSystemLustre) MkfsDefault() string {
+	return map[string]string{
+		TargetMGT:    "--mgs $VOL_NAME",
+		TargetMDT:    "--mdt --fsname=$FS_NAME --mgsnode=$MGS_NID --index=$INDEX $VOL_NAME",
+		TargetMGTMDT: "--mgs --mdt --fsname=$FS_NAME --index=$INDEX $VOL_NAME",
+		TargetOST:    "--ost --fsname=$FS_NAME --mgsnode=$MGS_NID --index=$INDEX $VOL_NAME",
+	}[f.TargetType]
+}
 
 func (f *FileSystemLustre) Create(devices []string, options FileSystemOptions) error {
 

--- a/pkg/manager-server/file_system_lvm.go
+++ b/pkg/manager-server/file_system_lvm.go
@@ -47,6 +47,11 @@ func init() {
 }
 
 func (*FileSystemLvm) New(oem FileSystemOem) (FileSystemApi, error) {
+
+	if oem.LvmCmd.IsZero() {
+		oem.LvmCmd = oem.LvmCmd.Defaults()
+	}
+
 	return &FileSystemLvm{
 		FileSystem: FileSystem{name: oem.Name},
 		CmdArgs:    oem.LvmCmd,
@@ -83,10 +88,7 @@ func (f *FileSystemLvm) Create(devices []string, opts FileSystemOptions) error {
 		return err
 	}
 
-	rsp, _ := f.run(fmt.Sprintf("lvdisplay %s || echo 'not found'", f.vgName))
-	if len(rsp) != 0 && !strings.Contains(string(rsp), "not found") {
-		// Volume Group is present, activate the volume. This is for the case where another
-		// node created the volume group and we just want to share it.
+	activateVolumeGroup := func() error {
 		shared := ""
 		if f.shared {
 			// Activate the shared lock
@@ -102,6 +104,13 @@ func (f *FileSystemLvm) Create(devices []string, opts FileSystemOptions) error {
 		}
 
 		return nil
+	}
+
+	rsp, _ := f.run(fmt.Sprintf("lvdisplay %s || echo 'not found'", f.vgName))
+	if len(rsp) != 0 && !strings.Contains(string(rsp), "not found") {
+		// Volume Group is present, activate the volume. This is for the case where another
+		// node created the volume group and we just want to share it.
+		return activateVolumeGroup()
 	}
 
 	varHandler := var_handler.NewVarHandler(map[string]string{
@@ -135,17 +144,12 @@ func (f *FileSystemLvm) Create(devices []string, opts FileSystemOptions) error {
 		return err
 	}
 
-	shared = ""
-	if f.shared {
-		if _, err := f.run(fmt.Sprintf("vgchange --lockstart %s", f.vgName)); err != nil {
-			return err
-		}
-
-		shared = "s"
+	if err := activateVolumeGroup(); err != nil {
+		return err
 	}
 
 	// Create the logical volume
-	// -Zn - don't zero the volume, it will fail.
+	// --zero n - don't zero the volume, it will fail.
 	// We are depending on the drive behavior for newly allocated blocks to track
 	// NVM Command Set spec, Section 3.2.3.2.1 Deallocated or Unwritten Logical Blocks
 	// The Kioxia drives support DLFEAT=001b
@@ -159,19 +163,14 @@ func (f *FileSystemLvm) Create(devices []string, opts FileSystemOptions) error {
 	// error is not enabled, the values read from a deallocated or unwritten block and its metadata (excluding protection information)
 	// shall be:
 	// • all bytes cleared to 0h if bits 2:0 in the DLFEAT field are set to 001b;
-	zeroOpt := "-Zn"
+	zeroOpt := "--zero n"
 	if _, ok := os.LookupEnv("NNF_SUPPLIED_DEVICES"); ok {
 		// On non-NVMe, let the zeroing happen so devices can be reused.
-		zeroOpt = "--yes"
+		zeroOpt = "--zero y"
 	}
 
 	lvArgs := varHandler.ReplaceAll(f.CmdArgs.LvCreate)
-	if _, err := f.run(fmt.Sprintf("lvcreate %s %s", zeroOpt, lvArgs)); err != nil {
-		return err
-	}
-
-	// Activate the volume group.
-	if _, err := f.run(fmt.Sprintf("vgchange --activate %sy %s", shared, f.vgName)); err != nil {
+	if _, err := f.run(fmt.Sprintf("lvcreate --yes %s %s", zeroOpt, lvArgs)); err != nil {
 		return err
 	}
 

--- a/pkg/manager-server/file_system_lvm.go
+++ b/pkg/manager-server/file_system_lvm.go
@@ -47,11 +47,6 @@ func init() {
 }
 
 func (*FileSystemLvm) New(oem FileSystemOem) (FileSystemApi, error) {
-
-	if oem.LvmCmd.IsZero() {
-		oem.LvmCmd = oem.LvmCmd.Defaults()
-	}
-
 	return &FileSystemLvm{
 		FileSystem: FileSystem{name: oem.Name},
 		CmdArgs:    oem.LvmCmd,
@@ -59,11 +54,13 @@ func (*FileSystemLvm) New(oem FileSystemOem) (FileSystemApi, error) {
 	}, nil
 }
 
-func (*FileSystemLvm) IsType(oem FileSystemOem) bool { return oem.Type == "lvm" }
-func (*FileSystemLvm) IsMockable() bool              { return false }
+func (*FileSystemLvm) IsType(oem *FileSystemOem) bool { return oem.Type == "lvm" }
+func (*FileSystemLvm) IsMockable() bool               { return false }
+func (*FileSystemLvm) Type() string                   { return "lvm" }
 
-func (*FileSystemLvm) Type() string   { return "lvm" }
 func (f *FileSystemLvm) Name() string { return f.name }
+
+func (f *FileSystemLvm) MkfsDefault() string { return "" }
 
 func (f *FileSystemLvm) Create(devices []string, opts FileSystemOptions) error {
 

--- a/pkg/manager-server/file_system_test.go
+++ b/pkg/manager-server/file_system_test.go
@@ -47,7 +47,7 @@ func _TestFileSystemZfs(t *testing.T) {
 
 	pool, ctrl := prepare(t, uuid.MustParse("00000000-0000-0000-0000-000000000000"))
 
-	oem := FileSystemOem{Name: "test", Type: "ZFS"}
+	oem := &FileSystemOem{Name: "test", Type: "ZFS"}
 	fs, err := ctrl.NewFileSystem(oem)
 	if err != nil {
 		t.Fatal(err)
@@ -69,7 +69,7 @@ func _TestFileSystemLvm(t *testing.T) {
 
 	pool, ctrl := prepare(t, uuid.MustParse("5d340875-a5c2-4e86-9406-37751954c022"))
 
-	oem := FileSystemOem{Name: "test", Type: "LVM"}
+	oem := &FileSystemOem{Name: "test", Type: "LVM"}
 	fs, err := ctrl.NewFileSystem(oem)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/manager-server/file_system_xfs.go
+++ b/pkg/manager-server/file_system_xfs.go
@@ -37,6 +37,15 @@ func init() {
 }
 
 func (*FileSystemXfs) New(oem FileSystemOem) (FileSystemApi, error) {
+
+	if oem.LvmCmd.IsZero() {
+		oem.LvmCmd = oem.LvmCmd.Defaults()
+	}
+
+	if oem.MkfsMount.IsZero() {
+		oem.MkfsMount = oem.MkfsMount.XfsDefaults()
+	}
+
 	return &FileSystemXfs{
 		FileSystemLvm: FileSystemLvm{
 			FileSystem: FileSystem{name: oem.Name},

--- a/pkg/manager-server/file_system_xfs.go
+++ b/pkg/manager-server/file_system_xfs.go
@@ -37,15 +37,6 @@ func init() {
 }
 
 func (*FileSystemXfs) New(oem FileSystemOem) (FileSystemApi, error) {
-
-	if oem.LvmCmd.IsZero() {
-		oem.LvmCmd = oem.LvmCmd.Defaults()
-	}
-
-	if oem.MkfsMount.IsZero() {
-		oem.MkfsMount = oem.MkfsMount.XfsDefaults()
-	}
-
 	return &FileSystemXfs{
 		FileSystemLvm: FileSystemLvm{
 			FileSystem: FileSystem{name: oem.Name},
@@ -55,11 +46,13 @@ func (*FileSystemXfs) New(oem FileSystemOem) (FileSystemApi, error) {
 	}, nil
 }
 
-func (*FileSystemXfs) IsType(oem FileSystemOem) bool { return oem.Type == "xfs" }
-func (*FileSystemXfs) IsMockable() bool              { return false }
+func (*FileSystemXfs) IsType(oem *FileSystemOem) bool { return oem.Type == "xfs" }
+func (*FileSystemXfs) IsMockable() bool               { return false }
+func (*FileSystemXfs) Type() string                   { return "xfs" }
 
-func (*FileSystemXfs) Type() string   { return "xfs" }
 func (f *FileSystemXfs) Name() string { return f.name }
+
+func (f *FileSystemXfs) MkfsDefault() string { return "$DEVICE" }
 
 func (f *FileSystemXfs) Create(devices []string, opts FileSystemOptions) (err error) {
 	if err := f.FileSystemLvm.Create(devices, opts); err != nil {

--- a/pkg/manager-server/file_system_zfs.go
+++ b/pkg/manager-server/file_system_zfs.go
@@ -37,11 +37,13 @@ func (*FileSystemZfs) New(oem FileSystemOem) (FileSystemApi, error) {
 	return &FileSystemZfs{FileSystem: FileSystem{name: oem.Name}}, nil
 }
 
-func (*FileSystemZfs) IsType(oem FileSystemOem) bool { return oem.Type == "zfs" }
-func (*FileSystemZfs) IsMockable() bool              { return false }
+func (*FileSystemZfs) IsType(oem *FileSystemOem) bool { return oem.Type == "zfs" }
+func (*FileSystemZfs) IsMockable() bool               { return false }
+func (*FileSystemZfs) Type() string                   { return "zfs" }
 
-func (*FileSystemZfs) Type() string   { return "zfs" }
 func (f *FileSystemZfs) Name() string { return f.name }
+
+func (f *FileSystemZfs) MkfsDefault() string { return "" }
 
 func (f *FileSystemZfs) Create(devices []string, options FileSystemOptions) error {
 

--- a/pkg/tests/filesystem/file_system_test.go
+++ b/pkg/tests/filesystem/file_system_test.go
@@ -125,11 +125,11 @@ func (t *testFileSystem) New(oem server.FileSystemOem) (server.FileSystemApi, er
 	return &testFileSystem{master: t, t: t.t, created: false, devices: nil, mountpoint: ""}, nil
 }
 
-func (*testFileSystem) IsType(oem server.FileSystemOem) bool { return oem.Type == "test" }
-func (*testFileSystem) IsMockable() bool                     { return true }
-
-func (*testFileSystem) Type() string { return "test" }
-func (*testFileSystem) Name() string { return "test" }
+func (*testFileSystem) IsType(oem *server.FileSystemOem) bool { return oem.Type == "test" }
+func (*testFileSystem) IsMockable() bool                      { return true }
+func (*testFileSystem) Type() string                          { return "test" }
+func (*testFileSystem) Name() string                          { return "test" }
+func (*testFileSystem) MkfsDefault() string                   { return "" }
 
 func (fs *testFileSystem) Create(devices []string, options server.FileSystemOptions) error {
 	fs.t.Logf("Test File System: Create File System: Devices: %+v Options: %+v", devices, options)


### PR DESCRIPTION
- Fix the delete share endpoint not registering the delete method
- Throw in some OEM defaults so nnf-ec can run standalone and support file-systems & file-shares. I'm not sure I like this implementation, it is a rather hacky way to get nnf-ec to where it was before the Storage Profile changes.
- Refactor LVM so the volume group is activated first. In my testing, this didn't change anything, but it allows me to use a common activation function, `activateVolumeGroup`, for both existing volumes from vgscan and new volumes.

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>