### PR TITLE
LVM Command Arguments for vgchange, vgremove, and lvremove

### DIFF
--- a/pkg/manager-server/file_system_api.go
+++ b/pkg/manager-server/file_system_api.go
@@ -76,7 +76,7 @@ type FileSystemApi interface {
 	New(oem FileSystemOem) (FileSystemApi, error)
 
 	IsType(oem *FileSystemOem) bool // Returns true if the provided oem fields match the file system type, false otherwise
-	IsMockable() bool   // Returns true if the file system can be instantiated by the mock server, false otherwise
+	IsMockable() bool               // Returns true if the file system can be instantiated by the mock server, false otherwise
 
 	Type() string
 	Name() string
@@ -85,7 +85,7 @@ type FileSystemApi interface {
 	Delete() error
 
 	MkfsDefault() string
-	
+
 	Mount(mountpoint string) error
 	Unmount(mountpoint string) error
 
@@ -212,6 +212,15 @@ type FileSystemOemLvm struct {
 
 	// The lvcreate commandline, minus the "lvcreate" command.
 	LvCreate string `json:"LvCreate,omitempty"`
+
+	// The vgchange commandline, minus the "vgchange" command.
+	VgChange string `json:"VgChange,omitempty"`
+	
+	// The vgremove commandline, minus the "vgremove" command.
+	VgRemove string `json:"VgRemove,omitempty"`
+
+	// The lvremove commandline, minus the "lvremove" command
+	LvRemove string `json:"LvRemove,omitempty"`
 }
 
 type FileSystemOemZfs struct {
@@ -255,6 +264,9 @@ func (oem *FileSystemOem) LoadDefaults(fs FileSystemApi) {
 		PvCreate: "$DEVICE",
 		VgCreate: "$VG_NAME $DEVICE_LIST",
 		LvCreate: "--extents 100%VG --stripes $DEVICE_NUM --stripesize 32KiB --name $LV_NAME $VG_NAME",
+		VgChange: "$VG_NAME",
+		VgRemove: "$VG_NAME",
+		LvRemove: "$VG_NAME",
 	}
 
 	oem.Gfs2 = FileSystemOemGfs2{

--- a/pkg/manager-server/file_system_api.go
+++ b/pkg/manager-server/file_system_api.go
@@ -84,6 +84,7 @@ type FileSystemApi interface {
 	Create(devices []string, opts FileSystemOptions) error
 	Delete() error
 
+	VgChangeActivateDefault() string
 	MkfsDefault() string
 
 	Mount(mountpoint string) error
@@ -214,13 +215,24 @@ type FileSystemOemLvm struct {
 	LvCreate string `json:"LvCreate,omitempty"`
 
 	// The vgchange commandline, minus the "vgchange" command.
-	VgChange string `json:"VgChange,omitempty"`
-	
+	VgChange FileSystemOemVgChange `json:"VgChange,omitempty"`
+
 	// The vgremove commandline, minus the "vgremove" command.
 	VgRemove string `json:"VgRemove,omitempty"`
 
 	// The lvremove commandline, minus the "lvremove" command
 	LvRemove string `json:"LvRemove,omitempty"`
+}
+
+type FileSystemOemVgChange struct {
+	// The vgchange commandline, minus the "vgchange" command
+	Activate string `json:"Activate,omitempty"`
+
+	// The vgchange commandline, minus the "vgchange" command
+	Deactivate string `json:"Deactivate,omitempty"`
+
+	// The vgchange commandline, minus the "vgchange" command
+	LockStart string `json:"Lockstart,omitempty"`
 }
 
 type FileSystemOemZfs struct {
@@ -264,7 +276,11 @@ func (oem *FileSystemOem) LoadDefaults(fs FileSystemApi) {
 		PvCreate: "$DEVICE",
 		VgCreate: "$VG_NAME $DEVICE_LIST",
 		LvCreate: "--extents 100%VG --stripes $DEVICE_NUM --stripesize 32KiB --name $LV_NAME $VG_NAME",
-		VgChange: "$VG_NAME",
+		VgChange: FileSystemOemVgChange{
+			Activate:   fs.VgChangeActivateDefault(),
+			Deactivate: "--activate n $VG_NAME",
+			LockStart:  "--lock-start $VG_NAME",
+		},
 		VgRemove: "$VG_NAME",
 		LvRemove: "$VG_NAME",
 	}

--- a/pkg/manager-server/file_system_gfs2.go
+++ b/pkg/manager-server/file_system_gfs2.go
@@ -86,6 +86,10 @@ func (*FileSystemGfs2) Type() string                   { return "gfs2" }
 
 func (f *FileSystemGfs2) Name() string { return f.name }
 
+func (*FileSystemGfs2) VgChangeActivateDefault() string {
+	return "--activate sy $VG_NAME"
+}
+
 func (*FileSystemGfs2) MkfsDefault() string {
 	return "-j2 -p $PROTOCOL -t $CLUSTER_NAME:$LOCK_SPACE $DEVICE"
 }

--- a/pkg/manager-server/file_system_lustre.go
+++ b/pkg/manager-server/file_system_lustre.go
@@ -88,6 +88,8 @@ func (*FileSystemLustre) Type() string     { return "lustre" }
 
 func (f *FileSystemLustre) Name() string { return f.name }
 
+func (f *FileSystemLustre) VgChangeActivateDefault() string { return "" }
+
 func (f *FileSystemLustre) MkfsDefault() string {
 	return map[string]string{
 		TargetMGT:    "--mgs $VOL_NAME",

--- a/pkg/manager-server/file_system_zfs.go
+++ b/pkg/manager-server/file_system_zfs.go
@@ -43,6 +43,7 @@ func (*FileSystemZfs) Type() string                   { return "zfs" }
 
 func (f *FileSystemZfs) Name() string { return f.name }
 
+func (f *FileSystemZfs) VgChangeActivateDefault() string { return "" }
 func (f *FileSystemZfs) MkfsDefault() string { return "" }
 
 func (f *FileSystemZfs) Create(devices []string, options FileSystemOptions) error {

--- a/pkg/tests/filesystem/file_system_test.go
+++ b/pkg/tests/filesystem/file_system_test.go
@@ -129,6 +129,7 @@ func (*testFileSystem) IsType(oem *server.FileSystemOem) bool { return oem.Type 
 func (*testFileSystem) IsMockable() bool                      { return true }
 func (*testFileSystem) Type() string                          { return "test" }
 func (*testFileSystem) Name() string                          { return "test" }
+func (*testFileSystem) VgChangeActivateDefault() string       { return "" }
 func (*testFileSystem) MkfsDefault() string                   { return "" }
 
 func (fs *testFileSystem) Create(devices []string, options server.FileSystemOptions) error {


### PR DESCRIPTION
I found it useful to have control over the vgchange and (lv|vg)remove options while testing recent changes to nnf-ec. rabbit-htx is currently not running lvmlockd since I am rebuilding the pacemaker cluster for the NNF fencing changes, so providing the `--nolocking` argument has proven quite useful. However, this could only be done on setup, hence I am adding (lv|vg)remove options for TOTAL CONTROL

Dean suggested I also add vgchange while I am at it, so I did. But vgchange only applies when activating, `--activate (y|n)`. I didn't apply the arguments to `vgchange --lock-start` because I thought that one should never be configurable. But if you think it's useful I could add it to the GFS2 options.

After merge, this will need coordination with nnf-sos and the default storage profile.

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>