### PR TITLE
Simple script to allocate & assign storage for compute nodes

### DIFF
--- a/scripts/allocate-compute.py
+++ b/scripts/allocate-compute.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 
-import argparse, sys, time
+import argparse, sys
 
 import common, connection
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Allocate storage and assign it to a compute node(s)',
-        epilog = 'Must executed on Rabbit with nnf-ec running')
-    
-    parser.add_argument('--node', nargs='+', choices=range(0,16), default=None, help='the node index to attach to')
+        epilog='Must be executed on Rabbit with nnf-ec running')
+
+    parser.add_argument('--node', nargs='+', choices=range(0, 16), default=None, help='the node index to attach to (default all 16 nodes)')
     parser.add_argument('--size', type=str, action=common.ByteSizeAction, default=common.ByteSizeStringToIntegerBytes('500GB'), help='storage pool size (default 500GB)')
 
     connection.addServerArguments(parser)
@@ -24,7 +24,7 @@ if __name__ == '__main__':
     for node in args.node:
         print(f"Starting Node '{node}' Sequence...")
 
-        print(f'\tCreating Storage Pool...', end=' ')
+        print('\tCreating Storage Pool...', end=' ')
 
         payload = {
             'Capacity': {'Data': {'AllocatedBytes': int(args.size)}},
@@ -36,18 +36,18 @@ if __name__ == '__main__':
             print(f'ERROR: {response.status_code}')
             print(f'RESPONSE: {response}')
             sys.exit(1)
-        
+
         pool_id = response.json()['Id']
         print(f"Created Storage Pool ID '{pool_id}'")
 
-        print(f'\tCreating Storage Group...', end=' ')
+        print('\tCreating Storage Group...', end=' ')
 
-        endpoint_id = node + 1 # Endpoint 0 is reserved for Rabbit
+        endpoint_id = node + 1  # Endpoint 0 is reserved for Rabbit
 
         payload = {
             'Links': {
-                'StoragePool': { '@odata.id': f'{conn.base}/StoragePools/{pool_id}'},
-                'ServerEndpoint': { '@odata.id': f'{conn.base}/Endpoints/{endpoint_id}'}
+                'StoragePool': {'@odata.id': f'{conn.base}/StoragePools/{pool_id}'},
+                'ServerEndpoint': {'@odata.id': f'{conn.base}/Endpoints/{endpoint_id}'}
             }
         }
 
@@ -68,16 +68,3 @@ if __name__ == '__main__':
 You can now create an LVM volume on each node that groups the NVMe block devices
 into a common file system. Refer to the lvm.sh script.
 """)
-
-
-"""
-cm power status -t node x9000c3s*b*n* | awk -F :  '{print $1}'
-readarray SYSTEMS < <(cm power status -t node x9000c3s*b*n* | awk -F :  '{print $1}')
-
-for SYSTEM in ${SYSTEMS[@]}; do ssh $SYSTEM 'for DRIVE in $(ls -v /dev/nvme* | grep -E "nvme[[:digit:]]+n[[:digit:]]+$"); do nvme id-ns $DRIVE | grep "NVME"; done'; done
-
-SYSTEM=${SYSTEMS[0]}
-ssh $SYSTEM 'for DRIVE in $(ls -v /dev/nvme* | grep -E "nvme[[:digit:]]+n[[:digit:]]+$"); do nvme id-ns $DRIVE | grep "NVME"; done'
-ssh $SYSTEM ls /dev/rabbit/rabbit
-
-"""

--- a/scripts/allocate-compute.py
+++ b/scripts/allocate-compute.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+import argparse, sys, time
+
+import common, connection
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Allocate storage and assign it to a compute node(s)',
+        epilog = 'Must executed on Rabbit with nnf-ec running')
+    
+    parser.add_argument('--node', nargs='+', choices=range(0,16), default=None, help='the node index to attach to')
+    parser.add_argument('--size', type=str, action=common.ByteSizeAction, default=common.ByteSizeStringToIntegerBytes('500GB'), help='storage pool size (default 500GB)')
+
+    connection.addServerArguments(parser)
+
+    args = parser.parse_args()
+
+    if args.node is None:
+        args.node = range(0, 16)
+
+    conn = connection.connect(args, '/redfish/v1/StorageServices/NNF')
+
+    for node in args.node:
+        print(f"Starting Node '{node}' Sequence...")
+
+        print(f'\tCreating Storage Pool...', end=' ')
+
+        payload = {
+            'Capacity': {'Data': {'AllocatedBytes': int(args.size)}},
+            'Oem': {'Compliance': 'relaxed'}
+        }
+
+        response = conn.post('/StoragePools', payload)
+        if not response.ok:
+            print(f'ERROR: {response.status_code}')
+            print(f'RESPONSE: {response}')
+            sys.exit(1)
+        
+        pool_id = response.json()['Id']
+        print(f"Created Storage Pool ID '{pool_id}'")
+
+        print(f'\tCreating Storage Group...', end=' ')
+
+        endpoint_id = node + 1 # Endpoint 0 is reserved for Rabbit
+
+        payload = {
+            'Links': {
+                'StoragePool': { '@odata.id': f'{conn.base}/StoragePools/{pool_id}'},
+                'ServerEndpoint': { '@odata.id': f'{conn.base}/Endpoints/{endpoint_id}'}
+            }
+        }
+
+        response = conn.post('/StorageGroups', payload)
+        if not response.ok:
+            print(f'ERROR: {response.status_code}')
+            print(f'RESPONSE: {response}')
+            sys.exit(1)
+
+        group_id = response.json()['Id']
+        print(f"Created Storage Group ID '{group_id}'")
+
+        print(f"Storage Node '{node}' Ready.")
+
+    print("")
+    print("All Nodes Ready")
+    print("""
+You can now create an LVM volume on each node that groups the NVMe block devices
+into a common file system. Refer to the lvm.sh script.
+""")
+
+
+"""
+cm power status -t node x9000c3s*b*n* | awk -F :  '{print $1}'
+readarray SYSTEMS < <(cm power status -t node x9000c3s*b*n* | awk -F :  '{print $1}')
+
+for SYSTEM in ${SYSTEMS[@]}; do ssh $SYSTEM 'for DRIVE in $(ls -v /dev/nvme* | grep -E "nvme[[:digit:]]+n[[:digit:]]+$"); do nvme id-ns $DRIVE | grep "NVME"; done'; done
+
+SYSTEM=${SYSTEMS[0]}
+ssh $SYSTEM 'for DRIVE in $(ls -v /dev/nvme* | grep -E "nvme[[:digit:]]+n[[:digit:]]+$"); do nvme id-ns $DRIVE | grep "NVME"; done'
+ssh $SYSTEM ls /dev/rabbit/rabbit
+
+"""


### PR DESCRIPTION
```
usage: allocate-compute.py [-h] [--node {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15} [{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15} ...]] [--size SIZE] [--host HOST] [--port PORT]

Allocate storage and assign it to a compute node(s)

optional arguments:
  -h, --help            show this help message and exit
  --node {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15} [{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15} ...]
                        the node index to attach to
  --size SIZE           storage pool size (default 500GB)
  --host HOST           specify a server endpoint
  --port PORT           specify a server port

Must executed on Rabbit with nnf-ec running
```

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>