### PR TITLE
RABSW-1097: Bind mount LVM devices and set permissions

### DIFF
--- a/pkg/manager-server/file_system_api.go
+++ b/pkg/manager-server/file_system_api.go
@@ -34,6 +34,11 @@ import (
 	"github.com/NearNodeFlash/nnf-ec/pkg/logging"
 )
 
+const (
+	UserID  = "userID"
+	GroupID = "groupID"
+)
+
 type FileSystemControllerApi interface {
 	NewFileSystem(oem *FileSystemOem) (FileSystemApi, error)
 }
@@ -120,6 +125,7 @@ func (f *FileSystem) mount(source string, target string, fstype string, options 
 	if !mounted {
 		if err := mounter.Mount(source, target, fstype, options); err != nil {
 			log.Errorf("Mount failed: %v", err)
+			return err
 		}
 	}
 
@@ -310,11 +316,6 @@ func (r *fileSystemRegistry) NewFileSystem(oem *FileSystemOem) (FileSystemApi, e
 }
 
 func setFileSystemPermissions(f FileSystemApi, opts FileSystemOptions) (err error) {
-	const (
-		UserID  = "userID"
-		GroupID = "groupID"
-	)
-
 	userID := 0
 	if _, exists := opts[UserID]; exists {
 		userID = opts[UserID].(int)

--- a/pkg/manager-server/file_system_lvm.go
+++ b/pkg/manager-server/file_system_lvm.go
@@ -20,17 +20,11 @@
 package server
 
 import (
-	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 	"time"
-
-	log "github.com/sirupsen/logrus"
-	"k8s.io/mount-utils"
 
 	"github.com/NearNodeFlash/nnf-ec/pkg/var_handler"
 )
@@ -47,8 +41,6 @@ type FileSystemLvm struct {
 	vgName  string
 	shared  bool
 	CmdArgs FileSystemOemLvm
-	uid     int
-	gid     int
 }
 
 func init() {
@@ -83,18 +75,6 @@ func (f *FileSystemLvm) Create(devices []string, opts FileSystemOptions) error {
 		f.lvName = opts[LogicalVolumeName].(string)
 	} else {
 		f.lvName = fmt.Sprintf("%s_lv", f.Name())
-	}
-
-	if _, exists := opts[UserID]; exists {
-		f.uid = opts[UserID].(int)
-	} else {
-		f.uid = 0
-	}
-
-	if _, exists := opts[GroupID]; exists {
-		f.gid = opts[GroupID].(int)
-	} else {
-		f.gid = 0
 	}
 
 	// TODO: Some sort of rollback mechanism on failure condition
@@ -234,60 +214,6 @@ func (f *FileSystemLvm) Delete() error {
 }
 
 func (f *FileSystemLvm) Mount(mountpoint string) error {
-	// Make the parent directory
-	if err := os.MkdirAll(filepath.Dir(mountpoint), 0755); err != nil {
-		return err
-	}
-
-	// Create an empty file to bind mount the device onto
-	if err := os.WriteFile(mountpoint, []byte(""), 0644); err != nil {
-		return err
-	}
-
-	mounter := mount.New("")
-	mounted, err := mounter.IsMountPoint(mountpoint)
-	if err != nil {
-		return err
-	}
-
-	if !mounted {
-		if err := mounter.Mount(f.devPath(), mountpoint, "none", []string{"bind"}); err != nil {
-			log.Errorf("Mount failed: %v", err)
-			return err
-		}
-
-		if err := os.Chown(f.devPath(), f.uid, f.gid); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (f *FileSystemLvm) Unmount(mountpoint string) error {
-	if mountpoint == "" {
-		return nil
-	}
-
-	mounter := mount.New("")
-	mounted, err := mounter.IsMountPoint(mountpoint)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return nil
-		}
-
-		return err
-	}
-
-	if mounted {
-		if err := mounter.Unmount(mountpoint); err != nil {
-			log.Errorf("Unmount failed: %v", err)
-			return err
-		}
-	}
-
-	_ = os.RemoveAll(filepath.Dir(mountpoint)) // Attempt to remove the directory but don't fuss about it if not
-
 	return nil
 }
 

--- a/pkg/manager-server/file_system_raw.go
+++ b/pkg/manager-server/file_system_raw.go
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020, 2021, 2022, 2023 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"os"
+	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/mount-utils"
+)
+
+type FileSystemRaw struct {
+	FileSystemLvm
+
+	uid     int
+	gid     int
+}
+
+func init() {
+	FileSystemRegistry.RegisterFileSystem(&FileSystemRaw{})
+}
+
+func (*FileSystemRaw) New(oem FileSystemOem) (FileSystemApi, error) {
+	return &FileSystemRaw{
+		FileSystemLvm: FileSystemLvm{
+			FileSystem: FileSystem{name: oem.Name},
+			CmdArgs:    oem.LvmCmd,
+			shared:     false,
+		},
+	}, nil
+}
+
+func (*FileSystemRaw) IsType(oem *FileSystemOem) bool { return oem.Type == "raw" }
+func (*FileSystemRaw) Type() string                   { return "raw" }
+
+
+func (f *FileSystemRaw) Create(devices []string, opts FileSystemOptions) error {
+	if err := f.FileSystemLvm.Create(devices, opts); err != nil {
+		return err
+	}
+
+	if _, exists := opts[UserID]; exists {
+		f.uid = opts[UserID].(int)
+	} else {
+		f.uid = 0
+	}
+
+	if _, exists := opts[GroupID]; exists {
+		f.gid = opts[GroupID].(int)
+	} else {
+		f.gid = 0
+	}
+
+	return nil
+}
+
+func (f *FileSystemRaw) Mount(mountpoint string) error {
+	// Make the parent directory
+	if err := os.MkdirAll(filepath.Dir(mountpoint), 0755); err != nil {
+		return err
+	}
+
+	// Create an empty file to bind mount the device onto
+	if err := os.WriteFile(mountpoint, []byte(""), 0644); err != nil {
+		return err
+	}
+
+	mounter := mount.New("")
+	mounted, err := mounter.IsMountPoint(mountpoint)
+	if err != nil {
+		return err
+	}
+
+	if !mounted {
+		if err := mounter.Mount(f.devPath(), mountpoint, "none", []string{"bind"}); err != nil {
+			log.Errorf("Mount failed: %v", err)
+			return err
+		}
+
+		if err := os.Chown(f.devPath(), f.uid, f.gid); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
 - Mounts weren't working for Raw allocations because they were creating a directory instead of a file to mount
 - User and group are set on the device bind mount so user containers can access them

Signed-off-by: Matt Richerson <matthew.richerson@hpe.com>