### PR TITLE
Add ep-tunnel commands for switch.sh

### DIFF
--- a/tools/_util.sh
+++ b/tools/_util.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Retrieve the Physical Device Fabric IDs used to iterate through a list of nvme drives
+function getPDFIDs() {
+    local SWITCH=$1
+
+    switchtec fabric gfms-dump "$SWITCH" | grep "Function 0 " -A2 | grep PDFID | awk '{print $2}'
+}

--- a/tools/nvme.sh
+++ b/tools/nvme.sh
@@ -19,6 +19,9 @@
 
 shopt -s expand_aliases
 
+# Pull in common utility functions
+source ./_util.sh
+
 usage() {
     cat <<EOF
 Run various NVMe Namespace commands over the NVMe switch fabric using
@@ -64,6 +67,7 @@ EOF
 execute() {
     local FUNCTION=$1 ARGS=( "${@:2}" )
 
+    # shellcheck disable=SC2086
     if [ "$(type -t $FUNCTION)" != "function" ]; then
         echo "$1 is not a function."
         exit 1
@@ -72,7 +76,7 @@ execute() {
     SWITCHES=("/dev/switchtec0" "/dev/switchtec1")
     for SWITCH in "${SWITCHES[@]}";
     do
-        mapfile -t PDFIDS < <(switchtec fabric gfms-dump "${SWITCH}" | grep "Function 0 (SRIOV-PF)" -A1 | grep PDFID | awk '{print $2}')
+        mapfile -t PDFIDS < <(getPDFIDs "$SWITCH")
         for INDEX in "${!PDFIDS[@]}";
         do
             "$FUNCTION" "${PDFIDS[$INDEX]}@$SWITCH" "${ARGS[@]}"

--- a/tools/switch.sh
+++ b/tools/switch.sh
@@ -30,6 +30,8 @@ Commands:
     status                               display port status for Rabbit connections
     switchtec-status                     display switchtec utility's port status inf
     info                                 display switch hardware information
+    ep-tunnel-status                     display endpoint tunnel status for each drive
+    ep-tunnel-enable                     enable the endpoint tunnel for each drive
     fabric [COMMAND] [ARG [ARG]...]      execute the fabric COMMAND (default is gfms-dump)
 
     cmd [COMMAND] [ARG [ARG]...]         execute COMMAND on each switchtec device in the system.
@@ -260,6 +262,26 @@ if [ $# -lt 1 ]; then
     exit 1
 fi
 
+function ep-tunnel-command() {
+    local SWITCH=$1 CMD=$2
+    echo "Execute switch ep-tunnel $CMD on $SWITCH"
+
+    DRIVES=$(switchtec fabric gfms-dump "$SWITCH" | grep "SRIOV-PF" -A2 | grep PDFID | awk '{print $2}')
+    for DRIVE in $DRIVES;
+    do
+        case $CMD in
+            status)
+                printf "%s\t" "$DRIVE"
+                ;;
+            *)
+                ;;
+        esac
+        
+        TIME switchtec fabric ep-tunnel-cfg "$SWITCH" --cmd="$CMD" --pdfid="$DRIVE";
+    done
+}
+
+
 case $1 in
     slot-info)
         function slot-info() {
@@ -292,6 +314,20 @@ case $1 in
             TIME switchtec status "$SWITCH"
         }
         execute switchtec-status
+        ;;
+    ep-tunnel-status)
+        function ep-tunnel-status() {
+            local SWITCH=$1
+            ep-tunnel-command "$SWITCH" "status"
+        }
+        execute ep-tunnel-status
+        ;;
+    ep-tunnel-enable)
+        function ep-tunnel-enable() {
+            local SWITCH=$1
+            ep-tunnel-command "$SWITCH" "enable"
+        }
+        execute ep-tunnel-enable
         ;;
     fabric)
         function fabric() {

--- a/tools/switch.sh
+++ b/tools/switch.sh
@@ -19,6 +19,9 @@
 
 shopt -s expand_aliases
 
+# Pull in common utility functions
+source ./_util.sh
+
 usage() {
     cat <<EOF
 Run various switch command over all switches.
@@ -266,7 +269,7 @@ function ep-tunnel-command() {
     local SWITCH=$1 CMD=$2
     echo "Execute switch ep-tunnel $CMD on $SWITCH"
 
-    DRIVES=$(switchtec fabric gfms-dump "$SWITCH" | grep "SRIOV-PF" -A2 | grep PDFID | awk '{print $2}')
+    DRIVES=$(getPDFIDs "$SWITCH")
     for DRIVE in $DRIVES;
     do
         case $CMD in
@@ -276,7 +279,7 @@ function ep-tunnel-command() {
             *)
                 ;;
         esac
-        
+
         TIME switchtec fabric ep-tunnel-cfg "$SWITCH" --cmd="$CMD" --pdfid="$DRIVE";
     done
 }


### PR DESCRIPTION
Looks like this:

[root@rabbit-node-1 tools]# ./switch.sh ep-tunnel-status
Execute switch ep-tunnel status on /dev/switchtec0
0x1300	Status: Enabled
0x1500	Status: Enabled
0x1a00	Status: Enabled
0x1900	Status: Enabled
0x1600	Status: Enabled
0x1400	Status: Enabled
0x1800	Status: Enabled
0x1700	Status: Enabled
Execute switch ep-tunnel status on /dev/switchtec1
0x3b00	Status: Enabled
0x3c00	Status: Enabled
0x3d00	Status: Enabled
0x3e00	Status: Enabled
0x3f00	Status: Enabled
0x4000	Status: Enabled
0x4200	Status: Enabled
0x4100	Status: Enabled

[root@RabbitP-CPU2 tools]# ./switch.sh ep-tunnel-enable
Execute switch ep-tunnel enable on /dev/switchtec0
Execute switch ep-tunnel enable on /dev/switchtec1

Signed-off-by: Anthony Floeder <anthony.floeder@hpe.com>