### PR TITLE
Insufficient functions for an endpoint should be a hard-error during …

### DIFF
--- a/pkg/manager-fabric/manager.go
+++ b/pkg/manager-fabric/manager.go
@@ -619,6 +619,10 @@ func (p *Port) Initialize() error {
 					panic(fmt.Sprintf("No EP Functions received for port %+v", port))
 				}
 
+				if len(epPort.Ep.Functions) == 1 {
+					return fmt.Errorf("Port %s: Single Root I/O Virtualization (SR-IOV) not supported", port.id)
+				}
+
 				f := port.swtch.fabric
 				if len(epPort.Ep.Functions) < 1 /*PF*/ +f.managementEndpointCount+f.upstreamEndpointCount {
 					log.Warnf("Port %s: Insufficient function count %d", port.id, len(epPort.Ep.Functions))


### PR DESCRIPTION
…initialization

Log output is:

```
INFO[0000] Initialize Port 10: Name: SSD 9 Physical Port: 8
INFO[0000] Initialize Port: Switch 1 enumerting DSP 8
WARN[0000] Initialize Port: Port Enumeration Failed: Physical Port 8  error="Port 10: Single Root I/O Virtualization (SR-IOV) not supported"
ERRO[0000] Switch 1 Port 10 failed to initialize         error="Port 10: Single Root I/O Virtualization (SR-IOV) not supported"
```

Signed-off-by: Anthony Floeder <anthony.floeder@hpe.com>