### PR TITLE
NVMe Identify Primary Controller Capabilities

### DIFF
--- a/internal/switchtec/cmd/nvme/primary_ctrl_caps.go
+++ b/internal/switchtec/cmd/nvme/primary_ctrl_caps.go
@@ -31,7 +31,7 @@ type PrimaryCtrlCapsCmd struct {
 	ControllerId uint16 `kong:"arg,optional,short='c',default='0',help='Controller ID'"`
 }
 
-// Run will run the List Namespace Command.
+// Run will run the Primary Controller Capabilities command
 func (cmd *PrimaryCtrlCapsCmd) Run() error {
 
 	return run(cmd.Device, func(dev *nvme.Device) error {

--- a/internal/switchtec/cmd/nvme/primary_ctrl_caps.go
+++ b/internal/switchtec/cmd/nvme/primary_ctrl_caps.go
@@ -40,7 +40,7 @@ func (cmd *PrimaryCtrlCapsCmd) Run() error {
 			return err
 		}
 
-		fmt.Printf("Identify Primary Controller:\n")
+		fmt.Printf("Identify Primary Controller Capabilities:\n")
 		fmt.Printf("%-6s: %-42s : %#x\n", "CNTLID", "Controller Identifier", caps.ControllerId)
 		fmt.Printf("%-6s: %-42s : %#x\n", "PORTID", "Port Identifier", caps.PortId)
 		fmt.Printf("%-6s: %-42s : %#x\n", "CRT", "Controller Resource Type", caps.ControllerResourceType)

--- a/internal/switchtec/cmd/nvme/primary_ctrl_caps.go
+++ b/internal/switchtec/cmd/nvme/primary_ctrl_caps.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nvme
+
+import (
+	"fmt"
+
+	"github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/nvme"
+)
+
+// PrimaryCtrlCapsCmd Send NVMe Identify Primary Controller Capabilities
+type PrimaryCtrlCapsCmd struct {
+	Device       string `kong:"arg,required,type='existingFile',help='The nvme device or device over switchtec tunnel'"`
+	ControllerId uint16 `kong:"arg,optional,short='c',default='0',help='Controller ID'"`
+}
+
+// Run will run the List Namespace Command.
+func (cmd *PrimaryCtrlCapsCmd) Run() error {
+
+	return run(cmd.Device, func(dev *nvme.Device) error {
+		caps, err := dev.IdentifyPrimaryControllerCapabilities(cmd.ControllerId)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Identify Primary Controller:\n")
+		fmt.Printf("%-6s: %-42s : %#x\n", "CNTLID", "Controller Identifier", caps.ControllerId)
+		fmt.Printf("%-6s: %-42s : %#x\n", "PORTID", "Port Identifier", caps.PortId)
+		fmt.Printf("%-6s: %-42s : %#x\n", "CRT", "Controller Resource Type", caps.ControllerResourceType)
+
+		fmt.Printf("%-6s: %-42s : %d\n", "VQFRT", "VQ Resources Flexible Total", caps.VQResourcesFlexibleTotal)
+		fmt.Printf("%-6s: %-42s : %d\n", "VQRFA", "VQ Resources Flexible Assigned", caps.VQResourcesFlexibleAssigned)
+		fmt.Printf("%-6s: %-42s : %d\n", "VQRFAP", "VQ Resources Flexible Allocated to Primary", caps.VQResourcesFlexibleAllocatedToPrimary)
+		fmt.Printf("%-6s: %-42s : %d\n", "VQPRT", "VQ Resources Private Total", caps.VQResourcesPrivateTotal)
+		fmt.Printf("%-6s: %-42s : %d\n", "VQFRSM", "VQ Resources Flexible Secondary Maximum", caps.VQResourcesFlexibleSecondaryMaximum)
+		fmt.Printf("%-6s: %-42s : %d\n", "VQGRAN", "VQ Flexible Resource Preferred Granularity", caps.VQFlexibleResourcePreferredGranularity)
+
+		fmt.Printf("%-6s: %-42s : %d\n", "VIFRT", "VI Resources Flexible Total", caps.VIResourcesFlexibleTotal)
+		fmt.Printf("%-6s: %-42s : %d\n", "VIRFA", "VI Resources Flexible Assigned", caps.VIResourcesFlexibleAssigned)
+		fmt.Printf("%-6s: %-42s : %d\n", "VIRFAP", "VI Resources Flexible Allocated to Primary", caps.VIResourcesFlexibleAllocatedToPrimary)
+		fmt.Printf("%-6s: %-42s : %d\n", "VIPRT", "VI Resources Private Total", caps.VIResourcesPrivateTotal)
+		fmt.Printf("%-6s: %-42s : %d\n", "VIFRSM", "VI Resources Flexible Secondary Maximum", caps.VIResourcesFlexibleSecondaryMaximum)
+		fmt.Printf("%-6s: %-42s : %d\n", "VIGRAN", "VI Flexible Resource Preferred Granularity", caps.VIFlexibleResourcePreferredGranularity)
+
+		return nil
+
+	})
+}

--- a/internal/switchtec/main.go
+++ b/internal/switchtec/main.go
@@ -43,22 +43,23 @@ var cli struct {
 	Event    cmd.EventCmd     `kong:"cmd,help='Event commands.'"`
 	Bw       cmd.BandwidthCmd `kong:"cmd,help='Measure the traffic bandwidth through each port.'"`
 
-	IdCtrl         nvme.IdCtrlCmd         `kong:"cmd,help='Identify Controller.'"`
-	IdNs           nvme.IdNsCmd           `kong:"cmd,help='IdentifyNamespace.'"`
-	ListNs         nvme.ListNsCmd         `kong:"cmd,help='List Namespace.'"`
-	IdNsCtrls      nvme.IdNamespaceCtrls  `kong:"cmd,help='Identify Controller attached to Namespace.'"`
-	CreateNs       nvme.CreateNsCmd       `kong:"cmd,help='Create namespace.'"`
-	DeleteNs       nvme.DeleteNsCmd       `kong:"cmd,help='Delete namespace.'"`
-	FormatNs       nvme.FormatNsCmd       `kong:"cmd,help='Format namespace.'"`
-	AttachNs       nvme.AttachNsCmd       `kong:"cmd,help='attaches a namespace to the given controller or comma-sep list of controllers.'"`
-	DetachNs       nvme.DetachNsCmd       `kong:"cmd,help='detaches a namespace from the given controller or comma-sep list of controllers.'"`
-	ListSecondary  nvme.ListSecondaryCmd  `kong:"cmd,help='Show secondary controller list associated with the primary controller of the given device.'"`
-	VirtMgmt       nvme.VirtualMgmtCmd    `kong:"cmd,help='Virtualization command supported by primary NVMe controlers.'"`
-	GetFeature     nvme.GetFeatureCmd     `kong:"cmd,help='Get feature.'"`
-	SetFeature     nvme.SetFeatureCmd     `kong:"cmd,help='Set feature.'"`
-	GetSmartLog    nvme.GetSmartLogCmd    `kong:"cmd,help='Retrieve SMART log for the given device.'"`
-	BuildMiFeature nvme.BuildMiFeatureCmd `kong:"cmd,help='Build MI Metadata feature file with interactive terminal'"`
-	Discover       nvme.DiscoverCmd       `kong:"cmd,help='Discover NVMe devices by Serial Number, Model Number, or NQN.'"`
+	IdCtrl            nvme.IdCtrlCmd          `kong:"cmd,help='Identify Controller.'"`
+	IdPrimaryCtlrCaps nvme.PrimaryCtrlCapsCmd `kong:"cmd,help='Identify Primary Controller Capabilities.'"`
+	IdNs              nvme.IdNsCmd            `kong:"cmd,help='IdentifyNamespace.'"`
+	ListNs            nvme.ListNsCmd          `kong:"cmd,help='List Namespace.'"`
+	IdNsCtrls         nvme.IdNamespaceCtrls   `kong:"cmd,help='Identify Controller attached to Namespace.'"`
+	CreateNs          nvme.CreateNsCmd        `kong:"cmd,help='Create namespace.'"`
+	DeleteNs          nvme.DeleteNsCmd        `kong:"cmd,help='Delete namespace.'"`
+	FormatNs          nvme.FormatNsCmd        `kong:"cmd,help='Format namespace.'"`
+	AttachNs          nvme.AttachNsCmd        `kong:"cmd,help='attaches a namespace to the given controller or comma-sep list of controllers.'"`
+	DetachNs          nvme.DetachNsCmd        `kong:"cmd,help='detaches a namespace from the given controller or comma-sep list of controllers.'"`
+	ListSecondary     nvme.ListSecondaryCmd   `kong:"cmd,help='Show secondary controller list associated with the primary controller of the given device.'"`
+	VirtMgmt          nvme.VirtualMgmtCmd     `kong:"cmd,help='Virtualization command supported by primary NVMe controlers.'"`
+	GetFeature        nvme.GetFeatureCmd      `kong:"cmd,help='Get feature.'"`
+	SetFeature        nvme.SetFeatureCmd      `kong:"cmd,help='Set feature.'"`
+	GetSmartLog       nvme.GetSmartLogCmd     `kong:"cmd,help='Retrieve SMART log for the given device.'"`
+	BuildMiFeature    nvme.BuildMiFeatureCmd  `kong:"cmd,help='Build MI Metadata feature file with interactive terminal'"`
+	Discover          nvme.DiscoverCmd        `kong:"cmd,help='Discover NVMe devices by Serial Number, Model Number, or NQN.'"`
 
 	Config cfg.ConfigCmd `kong:"cmd,help='Configure device.'"`
 }

--- a/internal/switchtec/pkg/nvme/nvme.go
+++ b/internal/switchtec/pkg/nvme/nvme.go
@@ -362,6 +362,26 @@ func (dev *Device) IdentifyNamespaceControllerList(namespaceId uint32) (*CtrlLis
 	return ctrlList, nil
 }
 
+func (dev *Device) IdentifyPrimaryControllerCapabilities(controllerId uint16) (*CtrlCaps, error) {
+
+	caps := new(CtrlCaps)
+	buf := structex.NewBuffer(caps)
+
+	var cdw10 uint32
+	cdw10 = uint32(controllerId) << 16
+	cdw10 |= uint32(PrimaryControllerCapabilities_CNS)
+
+	if err := dev.IdentifyRaw(0, cdw10, 0, buf.Bytes()); err != nil {
+		return nil, err
+	}
+
+	if err := structex.Decode(buf, caps); err != nil {
+		return nil, err
+	}
+
+	return caps, nil
+}
+
 // Identify -
 func (dev *Device) Identify(namespaceId uint32, cns IdentifyControllerOrNamespaceType, data []byte) error {
 	return dev.IdentifyRaw(namespaceId, uint32(cns), 0, data)
@@ -639,6 +659,27 @@ type NamespaceCapabilities struct {
 type CtrlList struct {
 	Num         uint16 `countOf:"Identifiers"`
 	Identifiers [2047]uint16
+}
+
+type CtrlCaps struct {
+	ControllerId                           uint16 // CNTLID
+	PortId                                 uint16 // PORTID
+	ControllerResourceType                 uint8  // CRT
+	Reserved5                              [27]uint8
+	VQResourcesFlexibleTotal               uint32 // VQFRT
+	VQResourcesFlexibleAssigned            uint32 // VQRFA
+	VQResourcesFlexibleAllocatedToPrimary  uint16 // VQRFAP
+	VQResourcesPrivateTotal                uint16 // VQPRT
+	VQResourcesFlexibleSecondaryMaximum    uint16 // VQFRSM
+	VQFlexibleResourcePreferredGranularity uint16 // VQGRAN
+	Reserved48                             [16]uint8
+	VIResourcesFlexibleTotal               uint32 // VIFRT
+	VIResourcesFlexibleAssigned            uint32 // VIRFA
+	VIResourcesFlexibleAllocatedToPrimary  uint16 // VIRFAP
+	VIResourcesPrivateTotal                uint16 // VIPRT
+	VIResourcesFlexibleSecondaryMaximum    uint16 // VIFRSM
+	VIFlexibleResourcePreferredGranularity uint16 // VIGRAN
+	Reserved90                             [4016]uint8
 }
 
 // CreateNamespace creates a new namespace with the specified parameters


### PR DESCRIPTION
Looks like this
```bash
# ./nate id-primary-ctlr-caps 0x1A00@/dev/switchtec0
Identify Primary Controller:
CNTLID: Controller Identifier                      : 0x81
PORTID: Port Identifier                            : 0x0
CRT   : Controller Resource Type                   : 0x3
VQFRT : VQ Resources Flexible Total                : 192
VQRFA : VQ Resources Flexible Assigned             : 1
VQRFAP: VQ Resources Flexible Allocated to Primary : 0
VQPRT : VQ Resources Private Total                 : 128
VQFRSM: VQ Resources Flexible Secondary Maximum    : 8
VQGRAN: VQ Flexible Resource Preferred Granularity : 1
VIFRT : VI Resources Flexible Total                : 192
VIRFA : VI Resources Flexible Assigned             : 1
VIRFAP: VI Resources Flexible Allocated to Primary : 0
VIPRT : VI Resources Private Total                 : 128
VIFRSM: VI Resources Flexible Secondary Maximum    : 8
VIGRAN: VI Flexible Resource Preferred Granularity : 1
```
Signed-off-by: Nate Thornton <nate.thornton@hpe.com>