### PR TITLE
Add chassis manager scripts to launch things across rabbits and compu…

### DIFF
--- a/scripts/allocate-compute.py
+++ b/scripts/allocate-compute.py
@@ -1,16 +1,38 @@
 #!/usr/bin/env python3
 
-import argparse, sys
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-import common, connection
+
+import argparse
+import sys
+
+import common
+import connection
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
-        description='Allocate storage and assign it to a compute node(s)',
-        epilog='Must be executed on Rabbit with nnf-ec running')
+        description='Allocate and attach Rabbit NVMe storage to one or more compute nodes',
+        epilog='NOTE: "nnf-ec" must be running on the Rabbit')
 
-    parser.add_argument('--node', nargs='+', choices=range(0, 16), default=None, help='the node index to attach to (default all 16 nodes)')
-    parser.add_argument('--size', type=str, action=common.ByteSizeAction, default=common.ByteSizeStringToIntegerBytes('500GB'), help='storage pool size (default 500GB)')
+    parser.add_argument('--node', nargs='+', type=int, choices=range(0, 16), default=None,
+                        help='compute node index to attach to (default all 16 nodes), specify "0" "1" ... for the compute nodes you want to use')
+    parser.add_argument('--size', type=str, action=common.ByteSizeAction,
+                        default=common.ByteSizeStringToIntegerBytes('500GB'), help='storage pool size (default 500GB)')
 
     connection.addServerArguments(parser)
 

--- a/scripts/chassis-manager-scripts/collectFioResultsEveryOther.sh
+++ b/scripts/chassis-manager-scripts/collectFioResultsEveryOther.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# set -e
+# set -o xtrace
+
+computeNodes=(
+    x9000c3s0b0n0
+    # x9000c3s0b1n0
+    x9000c3s1b0n0
+    # x9000c3s1b1n0
+    x9000c3s2b0n0
+    # x9000c3s2b1n0
+    x9000c3s3b0n0
+    # x9000c3s3b1n0
+    x9000c3s4b0n0
+    # x9000c3s4b1n0
+    x9000c3s5b0n0
+    # x9000c3s5b1n0
+    x9000c3s6b0n0
+    # x9000c3s6b1n0
+    x9000c3s7b0n0
+    # x9000c3s7b1n0
+)
+
+for nC in "${computeNodes[@]}";
+do
+    printf "Compute node %s:\n" "$nC"
+    rsync "$nC":results.* fio-results/
+done
+printf "\n"
+
+

--- a/scripts/chassis-manager-scripts/collectFioResultsOnComputeNodesBugs.sh
+++ b/scripts/chassis-manager-scripts/collectFioResultsOnComputeNodesBugs.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# set -e
+# set -o xtrace
+
+computeNodes=(
+    x9000c3rbt7b0n0
+    x9000c3s0b0n0
+    x9000c3s0b1n0
+    x9000c3s1b0n0
+    x9000c3s1b1n0
+    x9000c3s2b0n0
+    x9000c3s2b1n0
+    x9000c3s3b0n0
+    x9000c3s3b1n0
+    x9000c3s4b0n0
+    x9000c3s4b1n0
+    x9000c3s5b0n0
+    x9000c3s5b1n0
+    x9000c3s6b0n0
+    x9000c3s6b1n0
+    x9000c3s7b0n0
+    x9000c3s7b1n0
+)
+
+for nC in "${computeNodes[@]}";
+do
+    printf "Compute node %s:\n" "$nC"
+    rsync "$nC":results.* fio-results/
+done
+printf "\n"
+
+

--- a/scripts/chassis-manager-scripts/createVolumeOnComputeNodesBugs.sh
+++ b/scripts/chassis-manager-scripts/createVolumeOnComputeNodesBugs.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# set -e
+# set -o xtrace
+
+computeNodes=(
+    x9000c3s0b0n0
+    x9000c3s0b1n0
+    x9000c3s1b0n0
+    x9000c3s1b1n0
+    x9000c3s2b0n0
+    x9000c3s2b1n0
+    x9000c3s3b0n0
+    x9000c3s3b1n0
+    x9000c3s4b0n0
+    x9000c3s4b1n0
+    x9000c3s5b0n0
+    x9000c3s5b1n0
+    x9000c3s6b0n0
+    x9000c3s6b1n0
+    x9000c3s7b0n0
+    x9000c3s7b1n0
+)
+
+for nC in "${computeNodes[@]}";
+do
+    printf "Compute node %s:\n" "$nC"
+    rsync lvm.sh "$nC":
+
+    rabbitVGS=$(ssh "$nC" 'vgs | grep rabbit')
+    if [ -z "${rabbitVGS[@]}" ];
+    then
+        # Retrieve the list of namespaces from each KIOXIA or 'SAMSUNG MZ3LO1T9HCJR' drive seen on the compute node and count this number of namespaces. We expect only 1
+        nameSpaceCount=$(ssh "$nC" 'for DRIVE in $(ls -v /dev/nvme* | grep -E "nvme[[:digit:]]+n[[:digit:]]+$"); do if [ "$(nvme id-ctrl ${DRIVE} | grep -e KIOXIA -e 'SAMSUNG MZ3LO1T9HCJR')" != "" ]; then nvme id-ns $DRIVE | grep "NVME"; fi; done | uniq | wc -l')
+        if ((nameSpaceCount > 1)); then
+            printf "Too many namespaces(%d), please examine your setup\n" "$nameSpaceCount"
+            exit 1
+        fi
+
+        # Pull the namespace list from each KIOXIA or 'SAMSUNG MZ3LO1T9HCJR' drive, we know there is only 1 now.
+        nameSpaceStr=$(ssh "$nC" 'for DRIVE in $(ls -v /dev/nvme* | grep -E "nvme[[:digit:]]+n[[:digit:]]+$"); do if [ "$(nvme id-ctrl ${DRIVE} | grep -e KIOXIA -e 'SAMSUNG MZ3LO1T9HCJR')" != "" ]; then nvme id-ns $DRIVE | grep "NVME"; fi; done | uniq')
+        nameSpaceID=$(echo $nameSpaceStr | sed 's|:||g' | awk '{print $4}')
+
+        # Create an LVM volume from the namespaces present
+        ssh "$nC" "./lvm.sh create rabbit $nameSpaceID"
+    fi
+done
+printf "\n"
+
+

--- a/scripts/chassis-manager-scripts/deleteVolumeOnComputeNodesBugs.sh
+++ b/scripts/chassis-manager-scripts/deleteVolumeOnComputeNodesBugs.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# set -e
+# set -o xtrace
+
+computeNodes=(
+    x9000c3s0b0n0
+    x9000c3s0b1n0
+    x9000c3s1b0n0
+    x9000c3s1b1n0
+    x9000c3s2b0n0
+    x9000c3s2b1n0
+    x9000c3s3b0n0
+    x9000c3s3b1n0
+    x9000c3s4b0n0
+    x9000c3s4b1n0
+    x9000c3s5b0n0
+    x9000c3s5b1n0
+    x9000c3s6b0n0
+    x9000c3s6b1n0
+    x9000c3s7b0n0
+    x9000c3s7b1n0
+)
+
+for nC in "${computeNodes[@]}";
+do
+    printf "Compute node %s:\n" "$nC"
+    rsync lvm.sh "$nC":
+
+    rabbitVGS=$(ssh "$nC" 'vgs | grep rabbit')
+    if ((${#rabbitVGS[@]} > 0));
+    then
+        nameSpaceStr=$(ssh "$nC" 'for DRIVE in $(ls -v /dev/nvme* | grep -E "nvme[[:digit:]]+n[[:digit:]]+$"); do if [ "$(nvme id-ctrl ${DRIVE} | grep KIOXIA)" != "" ]; then nvme id-ns $DRIVE | grep "NVME"; fi; done | uniq')
+        nameSpaceID=$(echo $nameSpaceStr | sed 's|:||g' | awk '{print $4}')
+
+        # Create an LVM volume from the namespaces present
+        ssh "$nC" "./lvm.sh delete rabbit $nameSpaceID"
+    fi
+done
+printf "\n"
+
+

--- a/scripts/chassis-manager-scripts/killFioOnComputeNodesBugs.sh
+++ b/scripts/chassis-manager-scripts/killFioOnComputeNodesBugs.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# set -e
+# set -o xtrace
+
+computeNodes=(
+    x9000c3s0b0n0
+    x9000c3s0b1n0
+    x9000c3s1b0n0
+    x9000c3s1b1n0
+    x9000c3s2b0n0
+    x9000c3s2b1n0
+    x9000c3s3b0n0
+    x9000c3s3b1n0
+    x9000c3s4b0n0
+    x9000c3s4b1n0
+    x9000c3s5b0n0
+    x9000c3s5b1n0
+    x9000c3s6b0n0
+    x9000c3s6b1n0
+    x9000c3s7b0n0
+    x9000c3s7b1n0
+)
+
+for nC in "${computeNodes[@]}";
+do
+    printf "Compute node %s:\n" "$nC"
+    ssh "$nC" "pkill fio && ps -aux | grep fio"
+done
+printf "\n"

--- a/scripts/chassis-manager-scripts/lvm.sh
+++ b/scripts/chassis-manager-scripts/lvm.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+usage() {
+    cat <<EOF
+Manage LVM volumes on Rabbit
+Usage: $0 COMMAND [ARGS...]
+
+Commands:
+    list-drives                         list the drives used in create/delete
+    create [NAME] [NAMESPACE-ID]        create an LVM volume all drives
+    delete [NAME] [NAMESPACE-ID]        delete an LVM volume
+EOF
+}
+
+DRIVES=()
+
+drives() {
+    local NAMESPACE=$1
+    DRIVES=()
+    for DRIVE in $(ls /dev/nvme* | grep -E "nvme[[:digit:]]+n[[:digit:]]+$");
+    do
+        if [ "$(nvme id-ctrl ${DRIVE} | grep KIOXIA)" != "" ];
+        then
+            echo "  Found Kioxia drive ${DRIVE}"
+            NAMESPACEID=$(nvme id-ns ${DRIVE} | grep -E '^NVME Identify Namespace [[:digit:]]+' | awk '{print $4}')
+            if [ "${NAMESPACEID::-1}" == "$NAMESPACE" ];
+            then
+                echo "    Found Namespace ${NAMESPACE}"
+
+                DRIVES+=(${DRIVE})
+            fi
+        fi
+    done
+
+    echo "${#DRIVES[@]} DRIVES: ${DRIVES[@]}"
+}
+
+join() {
+    local IFS="$1"
+    shift
+    echo "$*"
+}
+
+
+NAME=${2:-"rabbit"}
+NAMESPACE=${3:-"1"}
+
+case $1 in
+    list-drives)
+        drives $NAMESPACE
+        ;;
+    create)
+        drives $NAMESPACE
+        for DRIVE in ${DRIVES[@]};
+        do
+            echo "Creating Physical Volume '${DRIVE}'"
+            pvcreate ${DRIVE}
+        done
+
+        echo "Creating Volume Group '${NAME}'"
+        vgcreate ${NAME} $(join " " ${DRIVES[@]})
+
+        echo "Creating Logical Volume '${NAME}'"
+        lvcreate -Zn --extents 100%VG --stripes ${#DRIVES[@]} --stripesize 32KiB --name ${NAME} ${NAME}
+
+        echo "Activate Volume Group '${NAME}'"
+        vgchange --activate y ${NAME}
+
+        echo "DONE! Access the volume at /dev/${NAME}/${NAME}"
+        ;;
+    delete)
+        echo "Removing Logical Volume '${NAME}'"
+        lvremove --yes /dev/{$NAME}/${NAME}
+
+        echo "Deactivate Volume Group '${NAME}'"
+        vgchange --activate n ${NAME}
+
+        echo "Removing Volume Group'${NAME}'"
+        vgremove --yes ${NAME}
+
+        drives $NAMESPACE
+        for DRIVE in ${DRIVES};
+        do
+            echo "Remove Physical Volume '${DRIVE}'"
+            pvremove --yes ${DRIVE}
+        done
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac
+

--- a/scripts/chassis-manager-scripts/powercycle.sh
+++ b/scripts/chassis-manager-scripts/powercycle.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# set -e
+# set -o xtrace
+
+rabbitPXName="x1000c[0-7]rbt7b0n0"
+rabbitSXName="x1000c[0-7]rbt4b0"
+
+paxControl() {
+    local op=$1
+
+    if [ -z "$op" ];
+    then
+        printf "paxControl operation not set\n"
+        exit 1
+    fi
+
+    case "$op" in
+        On)
+            op="on"
+            ;;
+        Off)
+            op="off"
+            ;;
+        *)
+            printf "Invalid power cycle option: %s\n" "$op"
+            exit 1
+            ;;
+    esac
+
+    printf "Pax power: %s\n" "$op"
+    pdsh -w "$rabbitSXName" pax-power "$op"
+}
+
+rabbitPControl() {
+    local op=$1
+
+    if [ -z "$op" ];
+    then
+        printf "RabbitPControl operation not set\n"
+        exit 1
+    fi
+
+    case "$op" in
+        On)
+            op="on"
+            ;;
+        Off)
+            op="off"
+            ;;
+        *)
+            printf "Invalid power cycle option: %s\n" "$op"
+            exit 1
+            ;;
+    esac
+
+    printf "RabbitP power: %s\n" "$op"
+    cm power "$op" -t node "$rabbitPXName"
+}
+
+waitRabbitState() {
+    local desiredState=$1
+    if [ -z "$desiredState" ];
+    then
+        printf "waitRabbitState desiredState not set\n"
+        exit 1
+    fi
+
+    case "$desiredState" in
+        On)
+            ;;
+        Off)
+            ;;
+        PoweringOn)
+            ;;
+        BOOTED)
+            ;;
+        *)
+            printf "Invalid Rabbit power state: %s\n" "$desiredState"
+            exit 1
+            ;;
+    esac
+
+    local areWeThereYet="$(cm power status -t node $rabbitPXName | grep -v $desiredState)"
+    for ((i=0; ${#areWeThereYet} > 300; i++));
+    do
+        if (( i > 9 ));
+        then
+            printf "Waited too long\n"
+            exit 1
+        fi
+
+        sleep 1
+        areWeThereYet="$(cm power status -t node $rabbitPXName | grep -v $desiredState)"
+
+        if ((i % 10 == 0));
+        then
+            printf "%s\n" "$areWeThereYet"
+        fi
+    done
+
+    printf "Everything %s\n" "$desiredState"
+}
+
+rabbitPControl "Off"
+paxControl "Off"
+waitRabbitState "Off"
+
+paxControl "On"
+rabbitPControl "On"
+waitRabbitState "PoweringOn"
+
+waitRabbitState "BOOTED"
+
+
+
+
+
+# pdsh -w x1000c[0-7]rbt4b0 pax-power off | grep down
+
+# pdsh -w x1000c[0-7]rbt4b0 pax-power on
+
+# RabbitP power cycling:
+# cm power status -t node x1000c[0-7]rbt7b0n0
+
+# cm power off -t node x1000c[0-7]rbt7b0n0
+
+# cm power status -t node x1000c[0-7]rbt7b0n0
+
+# cm power on -t node x1000c[0-7]rbt7b0n0
+
+# watch 'cm power status -t node x1000c[0-7]rbt7b0n0'

--- a/scripts/chassis-manager-scripts/randomread.fio
+++ b/scripts/chassis-manager-scripts/randomread.fio
@@ -1,0 +1,13 @@
+[global]
+direct=1
+ioengine=libaio
+iodepth=128
+numjobs=4
+time_based
+group_reporting
+bs=4k
+runtime=60
+rw=randread
+
+[randread-rabbit]
+filename=/dev/rabbit/rabbit

--- a/scripts/chassis-manager-scripts/randomwrite.fio
+++ b/scripts/chassis-manager-scripts/randomwrite.fio
@@ -1,0 +1,13 @@
+[global]
+direct=1
+ioengine=libaio
+iodepth=128
+numjobs=4
+time_based
+group_reporting
+bs=4k
+runtime=60
+rw=randwrite
+
+[randwrite-rabbit]
+filename=/dev/rabbit/rabbit

--- a/scripts/chassis-manager-scripts/randrw.fio
+++ b/scripts/chassis-manager-scripts/randrw.fio
@@ -1,0 +1,13 @@
+[global]
+direct=1
+ioengine=libaio
+iodepth=128
+numjobs=4
+time_based
+group_reporting
+bs=4k
+runtime=28800
+rw=randrw
+
+[randrw-rabbit]
+filename=/dev/rabbit/rabbit

--- a/scripts/chassis-manager-scripts/read.fio
+++ b/scripts/chassis-manager-scripts/read.fio
@@ -1,0 +1,13 @@
+[global]
+direct=1
+ioengine=libaio
+iodepth=128
+numjobs=4
+time_based
+group_reporting
+bs=128k
+runtime=60
+rw=read
+
+[read-rabbit]
+filename=/dev/rabbit/rabbit

--- a/scripts/chassis-manager-scripts/restartStuckComputeNodesBugs.sh
+++ b/scripts/chassis-manager-scripts/restartStuckComputeNodesBugs.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+# set -o xtrace
+
+unbootedComputeNodes="$(cm power status -t node x9000c3s*b*n* | grep -v BOOTED | awk '{print $1}' | sed -e 's|:||g')"
+echo $unbootedComputeNodes
+
+powerDownSleep=10
+for nC in $unbootedComputeNodes;
+do
+    printf "Powering off ComputeNode %s\n" "$nC"
+    cm power off -t node "$nC"
+
+    printf "Sleeping %d seconds to let controller finish power down\n" "$powerDownSleep"
+    sleep "$powerDownSleep"
+    cm power on -t node "$nC"
+done

--- a/scripts/chassis-manager-scripts/scanBIOSNodeBugs.sh
+++ b/scripts/chassis-manager-scripts/scanBIOSNodeBugs.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+# set -o xtrace
+
+computeNodesNodeControllers=(
+    x9000c3s0b0
+    x9000c3s0b1
+    x9000c3s1b0
+    x9000c3s1b1
+    x9000c3s2b0
+    x9000c3s2b1
+    x9000c3s3b0
+    x9000c3s3b1
+    x9000c3s4b0
+    x9000c3s4b1
+    x9000c3s5b0
+    x9000c3s5b1
+    x9000c3s6b0
+    x9000c3s6b1
+    x9000c3s7b0
+    x9000c3s7b1
+)
+
+for nC in "${computeNodesNodeControllers[@]}";
+do
+    printf "Compute node %s BIOS:\n" "$nC"
+    curl -s -u root:initial0 -k -XGET https://"$nC"/redfish/v1/Systems/Node0 | jq | grep -i bios
+
+    printf "\n"
+done

--- a/scripts/chassis-manager-scripts/scanComputeNodeBugs.sh
+++ b/scripts/chassis-manager-scripts/scanComputeNodeBugs.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+# set -o xtrace
+
+computeNodes=(
+    x9000c3s0b0n0
+    x9000c3s0b1n0
+    x9000c3s1b0n0
+    x9000c3s1b1n0
+    x9000c3s2b0n0
+    x9000c3s2b1n0
+    x9000c3s3b0n0
+    x9000c3s3b1n0
+    x9000c3s4b0n0
+    x9000c3s4b1n0
+    x9000c3s5b0n0
+    x9000c3s5b1n0
+    x9000c3s6b0n0
+    x9000c3s6b1n0
+    x9000c3s7b0n0
+    x9000c3s7b1n0
+)
+
+for nC in "${computeNodes[@]}";
+do
+    printf "Compute node %s devices:\n" "$nC"
+    ssh "$nC" "ls -l /dev/nvme*"
+    ssh "$nC" "echo DeviceCount: && ls -l /dev/nvme* | wc -l"
+    printf "\n"
+done

--- a/scripts/chassis-manager-scripts/startFioAllComputes.sh
+++ b/scripts/chassis-manager-scripts/startFioAllComputes.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# set -e
+# set -o xtrace
+
+computeNodes=(
+    x9000c3s0b0n0
+    x9000c3s0b1n0
+    x9000c3s1b0n0
+    x9000c3s1b1n0
+    x9000c3s2b0n0
+    x9000c3s2b1n0
+    x9000c3s3b0n0
+    x9000c3s3b1n0
+    x9000c3s4b0n0
+    x9000c3s4b1n0
+    x9000c3s5b0n0
+    x9000c3s5b1n0
+    x9000c3s6b0n0
+    x9000c3s6b1n0
+    x9000c3s7b0n0
+    x9000c3s7b1n0
+)
+
+
+printf "rsync .fio configurations\n"
+for nC in "${computeNodes[@]}";
+do
+    rsync *.fio "$nC":
+done
+
+fioFiles=(*.fio)
+
+for file in "${fioFiles[@]}";
+do
+    operation=$(cat $file | grep "rw=" | sed 's|rw=||g')
+    printf "  fio operation %s\n" "$operation"
+
+    for nC in "${computeNodes[@]}";
+    do
+        printf "Compute node %s:\n" "$nC"
+        ssh -f "$nC" "rm -f results.$operation.* && nohup fio $file > results.$operation.$nC &"
+
+        # The following section of commands works only if the fio version on the client matches the fio on the server!!!
+        # The following commands setup an fio server on each BP node
+        # ssh -f "$nC" "fio --server"
+        # This command launches fio on each BP node sending them the randomwrite.fio file
+        # fio --client="$nC" randomwrite.fio
+
+    done
+
+    sleepTime=$(( $(cat $file | grep runtime | sed 's|runtime=||g') + 5 ))
+    printf "  sleeping %d seconds for $operation to finish\n" "$sleepTime"
+    sleep "$sleepTime"
+done
+
+printf "\n"
+
+./collectFioResultsOnComputeNodesBugs.sh
+printf "\n"

--- a/scripts/chassis-manager-scripts/startFioAllComputesPlusRabbit.sh
+++ b/scripts/chassis-manager-scripts/startFioAllComputesPlusRabbit.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# set -e
+# set -o xtrace
+
+computeNodes=(
+    x9000c3s0b0n0
+    x9000c3s0b1n0
+    x9000c3s1b0n0
+    x9000c3s1b1n0
+    x9000c3s2b0n0
+    x9000c3s2b1n0
+    x9000c3s3b0n0
+    x9000c3s3b1n0
+    x9000c3s4b0n0
+    x9000c3s4b1n0
+    x9000c3s5b0n0
+    x9000c3s5b1n0
+    x9000c3s6b0n0
+    x9000c3s6b1n0
+    x9000c3s7b0n0
+    x9000c3s7b1n0
+    x9000c3rbt7b0n0
+)
+
+
+printf "rsync .fio configurations\n"
+for nC in "${computeNodes[@]}";
+do
+    rsync *.fio "$nC":
+done
+
+fioFiles=(*.fio)
+
+for file in "${fioFiles[@]}";
+do
+    operation=$(cat $file | grep "rw=" | sed 's|rw=||g')
+    printf "  fio operation %s\n" "$operation"
+
+    for nC in "${computeNodes[@]}";
+    do
+        printf "Compute node %s:\n" "$nC"
+        ssh -f "$nC" "rm -f results.$operation.* && nohup fio $file > results.$operation.$nC &"
+
+        # The following section of commands works only if the fio version on the client matches the fio on the server!!!
+        # The following commands setup an fio server on each BP node
+        # ssh -f "$nC" "fio --server"
+        # This command launches fio on each BP node sending them the randomwrite.fio file
+        # fio --client="$nC" randomwrite.fio
+
+    done
+
+    sleepTime=$(( $(cat $file | grep runtime | sed 's|runtime=||g') + 5 ))
+    printf "  sleeping %d seconds for %s to finish\n" "$sleepTime" "$operation"
+    sleep "$sleepTime"
+done
+
+printf "\n"
+
+./collectFioResultsOnComputeNodesBugs.sh
+printf "\n"

--- a/scripts/chassis-manager-scripts/startFioEveryOtherCompute.sh
+++ b/scripts/chassis-manager-scripts/startFioEveryOtherCompute.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# set -e
+# set -o xtrace
+
+computeNodes=(
+    x9000c3s0b0n0
+    # x9000c3s0b1n0
+    x9000c3s1b0n0
+    # x9000c3s1b1n0
+    x9000c3s2b0n0
+    # x9000c3s2b1n0
+    x9000c3s3b0n0
+    # x9000c3s3b1n0
+    x9000c3s4b0n0
+    # x9000c3s4b1n0
+    x9000c3s5b0n0
+    # x9000c3s5b1n0
+    x9000c3s6b0n0
+    # x9000c3s6b1n0
+    x9000c3s7b0n0
+    # x9000c3s7b1n0
+)
+
+
+printf "rsync .fio configurations\n"
+for nC in "${computeNodes[@]}";
+do
+    rsync *.fio "$nC":
+done
+
+fioFiles=(*.fio)
+
+for file in "${fioFiles[@]}";
+do
+    operation=$(cat $file | grep rw | sed 's|rw=||g')
+    printf "  fio operation %s\n" "$operation"
+
+    for nC in "${computeNodes[@]}";
+    do
+        printf "Compute node %s:\n" "$nC"
+        ssh -f "$nC" "rm -f results.$operation.* && nohup fio $file > results.$operation.$nC &"
+
+        # The following section of commands works only if the fio version on the client matches the fio on the server!!!
+        # The following commands setup an fio server on each BP node
+        # ssh -f "$nC" "fio --server"
+        # This command launches fio on each BP node sending them the randomwrite.fio file
+        # fio --client="$nC" randomwrite.fio
+
+    done
+
+    sleepTime=$(( $(cat $file | grep runtime | sed 's|runtime=||g') + 5 ))
+    printf "  sleeping %d seconds for $operation to finish\n" "$sleepTime"
+    sleep "$sleepTime"
+done
+
+printf "\n"
+
+./collectFioResultsEveryOther.sh
+printf "\n"

--- a/scripts/chassis-manager-scripts/startFioSingleCompute.sh
+++ b/scripts/chassis-manager-scripts/startFioSingleCompute.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# set -e
+# set -o xtrace
+
+computeNodes=(
+    x9000c3rbt7b0n0
+    x9000c3s0b0n0
+    x9000c3s0b1n0
+    x9000c3s1b0n0
+    x9000c3s1b1n0
+    x9000c3s2b0n0
+    x9000c3s2b1n0
+    x9000c3s3b0n0
+    x9000c3s3b1n0
+    x9000c3s4b0n0
+    x9000c3s4b1n0
+    x9000c3s5b0n0
+    x9000c3s5b1n0
+    x9000c3s6b0n0
+    x9000c3s6b1n0
+    x9000c3s7b0n0
+    x9000c3s7b1n0
+)
+
+
+printf "rsync .fio configurations\n"
+for nC in "${computeNodes[@]}";
+do
+    rsync *.fio "$nC":
+done
+
+fioFiles=(*.fio)
+
+for nC in "${computeNodes[@]}";
+do
+    printf "Node %s:\n" "$nC"
+
+    for file in "${fioFiles[@]}";
+    do
+        operation=$(cat $file | grep rw | sed 's|rw=||g')
+        printf "  fio operation %s\n" "$operation"
+
+        ssh -f "$nC" "rm -f results.$operation.* && nohup fio $file > results.$operation.$nC &"
+
+        # The following section of commands works only if the fio version on the client matches the fio on the server!!!
+        # The following commands setup an fio server on each BP node
+        # ssh -f "$nC" "fio --server"
+        # This command launches fio on each BP node sending them the randomwrite.fio file
+        # fio --client="$nC" randomwrite.fio
+
+        sleepTime=$(( $(cat $file | grep runtime | sed 's|runtime=||g') + 5 ))
+        printf "  sleeping %d seconds for $operation to finish\n" "$sleepTime"
+        sleep "$sleepTime"
+    done
+done
+
+printf "\n"
+
+./collectFioResultsOnComputeNodesBugs.sh
+printf "\n"

--- a/scripts/chassis-manager-scripts/updateBIOSComputeNodeBugs.sh
+++ b/scripts/chassis-manager-scripts/updateBIOSComputeNodeBugs.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+# set -o xtrace
+
+computeNodes=(
+    x9000c3s0b0
+    x9000c3s0b1
+    x9000c3s1b0
+    x9000c3s1b1
+    x9000c3s2b0
+    x9000c3s2b1
+    x9000c3s3b0
+    x9000c3s3b1
+    x9000c3s4b0
+    x9000c3s4b1
+    x9000c3s5b0
+    x9000c3s5b1
+    x9000c3s6b0
+    x9000c3s6b1
+    x9000c3s7b0
+    x9000c3s7b1
+)
+
+# if (($poweredOffCount < ${#computeNodes[@]})); then
+#     printf "Please power off all compute nodes to begin programming. %d nodes are powered off" "$poweredOffCount"
+#     cm power status -t node x9000c3s*b*n*
+#     exit 1
+# fi
+
+BIOS="ex235a.bios-1.6.1_SBIOS-2866_1.6.1_RabbitSupport.ROM"
+BIOSVERSION=$(echo $BIOS | sed 's|.ROM||g')
+echo $BIOS $BIOSVERSION
+# BIOS="ex235a.bios-1.6.0_SBIOS-2831_RabbitS_hotplug_support.ROM"
+# BIOS="ex235a.bios-1.6.0_SBIOS-2827_Verbose_tag2.ROM"
+
+for nC in "${computeNodes[@]}";
+do
+    # printf "Copy %s to compute node %s\n" "$BIOS" "$nC"
+    # scp "$BIOS" "$nC":/tmp
+
+    # printf "Flash %s on %s\n" "$BIOS" "$nC"
+    # ssh "$nC" "BIOS=$BIOS && echo BIOS=$BIOS && ls -l /tmp/ex* && node_flashbios 0 /tmp/$BIOS"
+
+    printf "Compute node %s BIOS\n" "$nC"
+    ssh "$nC" "cat /rwfs/.redfish/bios/bios_version.json.Node0 | jq"
+    # ssh "$nC" "curl -u root:initial0 -k -XGET https://x9000c3s0b0/redfish/v1/Systems/Node0 | jq | grep -i bios"
+    # ssh "$nC" "cat /var/log/n0/current | grep CRAY_VERSION | awk '{print $2}'"
+    # ssh "$nC" "cat /var/log/n0/current | grep CRAY_VERSION | awk '{print $3}'"
+
+    # printf "Compute node %s BIOS Settings\n" "$nC"
+    # ssh "$nC" "curl -u root:initial0 -k -XGET https://x9000c3s0b0/redfish/v1/Systems/Node0/Bios/SD | jq"
+
+    # printf "Compute node %s\n" "$nC"
+    # ssh "$nC" "ls /dev/nvme*"
+done

--- a/scripts/chassis-manager-scripts/updateRabbits.sh
+++ b/scripts/chassis-manager-scripts/updateRabbits.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+# set -o xtrace
+shopt -s expand_aliases
+
+usage() {
+    cat <<EOF
+Load tools and firmware files onto Rabbits.
+This script assumes it is part of a package of firmware, tool and script directories.
+
+Usage: $0 [-h]
+
+Arguments:
+  -h                display this help
+EOF
+}
+
+while getopts "h:" OPTION
+do
+    case "${OPTION}" in
+        'h',*)
+            usage
+            exit 0
+            ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+TLD="/root/ajf"
+
+# Find the list of Rabbits we need to tool-up
+rabbits=( $(cm node show | grep Rabbit) )
+# rabbits=( RabbitP-c0 )
+for rabbit in "${rabbits[@]}";
+do
+    ssh "$rabbit" "rm -rf tools scripts"
+    printf "$rabbit\n" "$rabbit"
+    rsync -r "$TLD"/KIOXIA "$rabbit":
+    rsync -r "$TLD"/Switchtec "$rabbit":
+    rsync "$TLD"/nnf-ec "$rabbit":
+    ssh "$rabbit" "chmod +x nnf-ec"
+    rsync -r "$TLD"/scripts "$rabbit":
+    rsync -r "$TLD"/tools "$rabbit":
+    rsync -r "$TLD"/switchtec* "$rabbit":/usr/src
+
+    # Compile/install switchtec-user, then copy the latest switchtec-nvme program into place to get the latest capabilities
+    ssh "$rabbit" "cd /usr/src/switchtec-user && ./configure && make install && cp /usr/src/switchtec-nvme-cli/switchtec-nvme /usr/sbin"
+
+    # Launch nnf-ec to initialize PAX's, drives and compute node endpoints
+    # type CTRL-C when you see "Starting HTTP Server	{"address": ":8080"}"
+    # to proceed to the next Rabbit.
+    ssh "$rabbit" "./nnf-ec"
+done

--- a/scripts/chassis-manager-scripts/write.fio
+++ b/scripts/chassis-manager-scripts/write.fio
@@ -1,0 +1,13 @@
+[global]
+direct=1
+ioengine=libaio
+iodepth=128
+numjobs=4
+time_based
+group_reporting
+bs=128k
+runtime=60
+rw=write
+
+[write-rabbit]
+filename=/dev/rabbit/rabbit

--- a/tools/nvme.sh
+++ b/tools/nvme.sh
@@ -21,6 +21,7 @@ shopt -s expand_aliases
 
 # Pull in common utility functions
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# shellcheck source="$SCRIPT_DIR"/_util.sh
 source "$SCRIPT_DIR"/_util.sh
 
 usage() {

--- a/tools/switch.sh
+++ b/tools/switch.sh
@@ -21,6 +21,7 @@ shopt -s expand_aliases
 
 # Pull in common utility functions
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# shellcheck source="$SCRIPT_DIR"/_util.sh
 source "$SCRIPT_DIR"/_util.sh
 
 usage() {


### PR DESCRIPTION
…te nodes

- Example scripts used during factory testing
- Debug allocate_compute.py script to allow specifying specific compute nodes