### PR TITLE
RABSW-1158: Add timeout to commands run by nnf-ec

### DIFF
--- a/pkg/manager-server/file_system_api.go
+++ b/pkg/manager-server/file_system_api.go
@@ -213,7 +213,7 @@ func (*FileSystem) run(cmd string) ([]byte, error) {
 		shellCmd.Stderr = &fsError.stderr
 		err := shellCmd.Run()
 		if err != nil {
-			// Command failed, return stderr
+			// Command failed, return FileSystemError with stdout and stderr
 			return nil, &fsError
 		}
 		// Command success, return stdout

--- a/pkg/manager-server/file_system_api.go
+++ b/pkg/manager-server/file_system_api.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"os/exec"
 	"reflect"
+	"strconv"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -191,17 +192,17 @@ func (*FileSystem) run(cmd string) ([]byte, error) {
 	return logging.Cli.Trace2(logging.LogToStdout, cmd, func(cmd string) ([]byte, error) {
 
 		ctx := context.Background()
-		timeoutString, found := os.LookupEnv("NNF_EC_COMMAND_TIMEOUT")
+		timeoutString, found := os.LookupEnv("NNF_EC_COMMAND_TIMEOUT_SECONDS")
 		if found {
 			var cancel context.CancelFunc
 
-			timeout, err := time.ParseDuration(timeoutString)
+			timeout, err := strconv.Atoi(timeoutString)
 			if err != nil {
 				return nil, err
 			}
 
 			if timeout > 0 {
-				ctx, cancel = context.WithTimeout(context.Background(), timeout)
+				ctx, cancel = context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
 				defer cancel()
 			}
 		}


### PR DESCRIPTION
Commands can sometimes hang forever without returning an error. Add a timeout whenever running commands. The
timeout is adjustable through the NNF_EC_COMMAND_TIMEOUT_SECONDS environment variable.`

Signed-off-by: Matt Richerson <matthew.richerson@hpe.com>
