### PR TITLE
Github-32: Clean up fileshare create after mount failure

### DIFF
--- a/pkg/manager-nnf/manager.go
+++ b/pkg/manager-nnf/manager.go
@@ -1416,6 +1416,10 @@ func (*StorageService) StorageServiceIdFileSystemIdExportedSharesPost(storageSer
 		}
 
 		if err := sg.serverStorage.MountFileSystem(fs.fsApi, sh.mountRoot); err != nil {
+			if deleteErr := sg.serverStorage.DeleteFileSystem(fs.fsApi); deleteErr != nil {
+				return ec.NewErrInternalServerError().WithResourceType(FileShareOdataType).WithError(deleteErr).WithCause(fmt.Sprintf("File share '%s' failed delete", sh.id))
+			}
+
 			return ec.NewErrInternalServerError().WithResourceType(FileShareOdataType).WithError(err).WithCause(fmt.Sprintf("File share '%s' mount failed", sh.id))
 		}
 

--- a/pkg/manager-nnf/manager.go
+++ b/pkg/manager-nnf/manager.go
@@ -1417,7 +1417,7 @@ func (*StorageService) StorageServiceIdFileSystemIdExportedSharesPost(storageSer
 
 		if err := sg.serverStorage.MountFileSystem(fs.fsApi, sh.mountRoot); err != nil {
 			if deleteErr := sg.serverStorage.DeleteFileSystem(fs.fsApi); deleteErr != nil {
-				return ec.NewErrInternalServerError().WithResourceType(FileShareOdataType).WithError(deleteErr).WithCause(fmt.Sprintf("File share '%s' failed delete", sh.id))
+				return ec.NewErrInternalServerError().WithResourceType(FileShareOdataType).WithError(deleteErr).WithCause(fmt.Sprintf("File share '%s' failed delete after mount failure", sh.id))
 			}
 
 			return ec.NewErrInternalServerError().WithResourceType(FileShareOdataType).WithError(err).WithCause(fmt.Sprintf("File share '%s' mount failed", sh.id))


### PR DESCRIPTION
If the mount of a fileshare failed, then the whole fileshare needs to be torn down since none of the partial setup information is saved.