### PR TITLE
For zfs backed lustre, skip zpool destroy if zpool list fails

### DIFF
--- a/pkg/manager-server/file_system_lustre.go
+++ b/pkg/manager-server/file_system_lustre.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, 2021, 2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2020-2023 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -148,14 +148,16 @@ func (f *FileSystemLustre) Delete() error {
 	var err error
 	if f.Oem.BackFs == BackFsZfs {
 		zpool := f.zfsPoolName()
+
 		// Query the existence of the pool.
 		_, err = f.run(fmt.Sprintf("zpool list %s", zpool))
-		if err != nil {
-			return err
-		}
-		_, err = f.run(fmt.Sprintf("zpool destroy %s", zpool))
-		if err != nil {
-			return err
+
+		// If no error, delete. Or if error found and it's something other than 'no such pool' error, delete.
+		if err == nil || (err != nil && !strings.Contains(err.Error(), "no such pool")) {
+			_, err = f.run(fmt.Sprintf("zpool destroy %s", zpool))
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/manager-server/file_system_lustre.go
+++ b/pkg/manager-server/file_system_lustre.go
@@ -152,7 +152,7 @@ func (f *FileSystemLustre) Delete() error {
 		// Query the existence of the pool.
 		_, err = f.run(fmt.Sprintf("zpool list %s", zpool))
 
-		// If no error, delete. Or if the pool still exists, delete it.
+		// If the pool exists, delete it.
 		if err == nil || (err != nil && !strings.Contains(err.Error(), "no such pool")) {
 			_, err = f.run(fmt.Sprintf("zpool destroy %s", zpool))
 			if err != nil {

--- a/pkg/manager-server/file_system_lustre.go
+++ b/pkg/manager-server/file_system_lustre.go
@@ -152,7 +152,7 @@ func (f *FileSystemLustre) Delete() error {
 		// Query the existence of the pool.
 		_, err = f.run(fmt.Sprintf("zpool list %s", zpool))
 
-		// If no error, delete. Or if error found and it's something other than 'no such pool' error, delete.
+		// If no error, delete. Or if the pool still exists, delete it.
 		if err == nil || (err != nil && !strings.Contains(err.Error(), "no such pool")) {
 			_, err = f.run(fmt.Sprintf("zpool destroy %s", zpool))
 			if err != nil {


### PR DESCRIPTION
Additionally, catch timeouts and include an error message to indicate timeout.

Tested by:
- Stubbing out zpool destroy with a sleep to hit the timeout
- In PostRun, exec into the node manager pod to unmount and destroy the zpool. Ensure Teardown completes successfully.