### PR TITLE
Retry CommonNamespaceIdentifier

### DIFF
--- a/internal/switchtec/pkg/nvme/nvme.go
+++ b/internal/switchtec/pkg/nvme/nvme.go
@@ -675,7 +675,7 @@ type IdNs struct {
 	LBAFormats                   [16]struct {
 		MetadataSize        uint16 // MS
 		LBADataSize         uint8  // LBADS Indicates the LBA data size supported in terms of a power-of-two value. If the value is 0, the the LBA format is not supported
-		RelativePerformance uint8  // RP indicates the relative performance of this LBA formt relative to other LBA formats
+		RelativePerformance uint8  // RP indicates the relative performance of this LBA format relative to other LBA formats
 	}
 	Reserved192    [192]uint8
 	VendorSpecific [3712]uint8

--- a/tools/rabbit-s.sh
+++ b/tools/rabbit-s.sh
@@ -83,11 +83,12 @@ case $CMD in
 
             echo "Enabling Logging on $PAX"
             $SSHPASS ssh -T root@$SYSTEM <<-EOF
-            [ "$(screen -ls | grep $PAX)" == "" ] &&
-            screen -dmS $DEVICE 230400 &&
-            screen -S $PAX -X colon "logfile $PAX.log^M" &&
-            screen -S $PAX -X colon "logfile flush 1^M" &&
-            screen -S $PAX -X colon "log on^M"
+            if ! screen -list | grep -q "$PAX"; then
+                screen -dmS $DEVICE 230400 &&
+                screen -S $PAX -X colon "logfile $PAX.log^M" &&
+                screen -S $PAX -X colon "logfile flush 1^M" &&
+                screen -S $PAX -X colon "log on^M"
+            fi
 EOF
         done
         ;;


### PR DESCRIPTION
Retry `identify common namespace` during initialization to recover from intermittent failures seen during power cycle testing.