### PR TITLE
Identify inability to open a switch, avoid nil dereference

### DIFF
--- a/pkg/manager-fabric/manager.go
+++ b/pkg/manager-fabric/manager.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, 2021, 2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2020-2024 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -381,6 +381,7 @@ func (s *Switch) identify() error {
 		if os.IsNotExist(err) {
 			continue
 		} else if err != nil {
+			s.path = "" // Test this; it's easier than testing s.dev.
 			log.Error(err, "Error opening path")
 			return err
 		}
@@ -785,6 +786,11 @@ func (p *Port) bind() error {
 							}
 
 							break
+						}
+
+						if s.path == "" {
+							// See s.identify()
+							panic(fmt.Sprintf("Unable to identify switch for port: Initiator Port %d, Logical Port %d, PDFID: %#04x", initiatorPort.config.Port, logicalPortId, endpoint.pdfid))
 						}
 
 						log.Info("Binding Port")


### PR DESCRIPTION
In the case where we cannot open a /dev/switchtecX device, give a useful panic message rather than just dereferencing a nil pointer.

Earlier in the log there will be an error stating "Error opening path", and another stating "Failed to identify switch". The nil deference was happening much later, so it was not obviously connected to those.

See https://github.com/NearNodeFlash/NearNodeFlash.github.io/issues/178 for more details.