### PR TITLE
tools script additions and improvements

### DIFF
--- a/tools/collectNVLogs.sh
+++ b/tools/collectNVLogs.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright 2024 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# set -e
+# set -o xtrace
+
+shopt -s expand_aliases
+
+logSources=("FLASH" "MEMLOG" "REGS" "THRD_STACK" "SYS_STACK" "THRDS" "NVHDR" "RAM")
+switches=("/dev/switchtec0" "/dev/switchtec1")
+
+for switch in "${switches[@]}"; do
+    PAX_ID=$(switchtec fabric gfms-dump "$switch" | grep "^PAX ID:" | awk '{print $3}')
+    if ! (( PAX_ID >= 0 && PAX_ID <= 1 )); then
+        echo "$PAX_ID not in range 0-1"
+        exit 1
+    fi
+
+    for logSource in "${logSources[@]}"; do
+        echo pax"$PAX_ID"-"$logSource".log
+        switchtec log-dump "$switch" pax"$PAX_ID"-"$logSource".log --type="$logSource"
+    done
+done

--- a/tools/rabbit-s.sh
+++ b/tools/rabbit-s.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.
 #
 # The entirety of this work is licensed under the Apache License,
@@ -181,6 +181,46 @@ EOF
 EOF
         done
         ;;
+    hpecray-29)
+        for SESSION in "${SESSIONS[@]}"
+        do
+
+            # For this run, we want to enable some logging settings that we have been leaving off for a while.
+            # FABIOV - 0x82
+            #     log -m 0x82 -s 3
+            #     log -m 0x82 -s 3 -p on
+            # PTD - 0x53
+            #     log -m 0x53 -s 3
+            #     log -m 0x53 -s 3 -p on
+            # fabdbg -s pax
+            # fabdbg -s fio
+            # fabdbg -s gfms
+
+            $SSHPASS ssh root@$SYSTEM <<-EOF
+            screen -S $SESSION -X stuff "fabdbg -s pax\nfabdbg -s fio\nfabdbg -s gfms\nlog -m 0x82 -s 3\nlog -m 0x82 -s 3 -p on\nlog -m 0x53 -s 3\nlog -m 0x53 -s 3 -p on\n"
+EOF
+        done
+        ;;
+    hpecray-32)
+        for SESSION in "${SESSIONS[@]}"
+        do
+            # Enables medium severity and turns on logging for the PSC module
+            # log -m 0x54 -s 3
+            # log -m 0x54 -s 3 -p on
+
+            # Enables logs for the fabric debug modules
+            # fabdbg -s pax
+            # fabdbg -s fio
+            # fabdbg -s gfms
+
+            # Turn on the logging for all modules
+            # log -p on
+            $SSHPASS ssh root@$SYSTEM <<-EOF
+            screen -S $SESSION -X stuff "fabdbg -s pax\nfabdbg -s fio\nfabdbg -s gfms\nlog -m 0x54 -s 3\nlog -m 0x54 -s 3 -p on\nlog -p on\n"
+EOF
+        done
+        ;;
+
     quit-sessions)
         for SESSION in "${SESSIONS[@]}"
         do

--- a/tools/show-drive-ports.sh
+++ b/tools/show-drive-ports.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+# Copyright 2024 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+usage() {
+    cat <<EOF
+Examine "lspci" status and report failing drive links
+Usage: $0 [-h] [-v]
+
+Arguments:
+  -v                verbose output
+  -h                display this help
+
+Examples:
+  $0 -v
+EOF
+}
+
+VERBOSE="false"
+while getopts ":vh" OPTION
+do
+    case "${OPTION}" in
+        'v')
+            VERBOSE="true"
+            ;;
+        'h')
+            usage
+            exit 0
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+drive_links="04 82"
+
+error_present="false"
+for pax in $drive_links;
+do
+    for drive in {0..8};
+    do
+        if [ $pax -eq 4  ] && [ $drive -eq 7 ]; then
+            continue
+        fi
+        if [ $pax -eq 82  ] && [ $drive -eq 4 ]; then
+            continue
+        fi
+
+        pci_result=$(lspci -s "$pax":"$drive".0 -vv | grep LnkSta:)
+        if [ $? -ne 0 ]; then
+            if [ $VERBOSE == "true" ]; then
+                printf "%d:%d.0 Error accessing drive\n" "$pax" "$drive";
+            fi
+            error_present="true"
+            continue
+        fi
+
+        access_error_result=$(echo "$pci_result" | grep "!!! Unknown header type")
+        if [ $? -eq 0 ]; then
+            if [ $VERBOSE == "true" ]; then
+                printf "%d:%d.0 Unable to retrieve link info\n" "$pax" "$drive"
+            fi
+            error_present="true"
+            continue
+        fi
+
+        width_zero_error_result=$(echo "$pci_result" | grep "Width x0")
+        if [ $? -eq 0 ]; then
+            if [ $VERBOSE == "true" ]; then
+                printf "%d:%d.0 Link down\n" "$pax" "$drive"
+            fi
+            error_present="true"
+            continue
+        fi
+
+        link_speed_error_result=$(echo "$pci_result" | grep 16GT)
+        if [ $? -ne 0 ]; then
+            if [ $VERBOSE == "true" ]; then
+                printf "%d:%d.0 Link speed too slow\n" "$pax" "$drive"
+            fi
+            error_present="true"
+            continue
+        fi
+    done;
+done
+
+if [ "$error_present" == "false" ]; then
+    printf "No errors\n"
+else
+    printf "ERRORS FOUND\n"
+fi

--- a/tools/timestamp-log.sh
+++ b/tools/timestamp-log.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2024 Hewlett Packard Enterprise Development LP
+# Copyright 2020, 2021, 2022 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.
 #
 # The entirety of this work is licensed under the Apache License,


### PR DESCRIPTION
tools/ script modifications and additions:
`collectNVLog.sh` - add the switchtec RAM log to the logs collected.
`rabbit-s.sh` - add log setting for issues we've seen in the switches
`show-drive-ports.sh` - test script to check drive PCI link speeds and widths as seen from Rabbit
`switch.sh` - Add verbose (-v) option to specify the x-name of the compute and rabbit nodes along with the temperature of the PAXs