### PR TITLE
Update switch.sh slot-info output

### DIFF
--- a/tools/switch.sh
+++ b/tools/switch.sh
@@ -253,10 +253,10 @@ displayDriveSlotStatus() {
                         Device="${deviceName["$SN"]}"
                         ;;
                     *)
-                        MF="$(echo "${idCtrl[0]}" | awk '{print $3}')"
-                        SN=""
-                        FW=""
-                        Device=""
+                        MF="Unavail"
+                        SN="Unavail"
+                        FW="Unavail"
+                        Device="Unavail"
                         ;;
                 esac
             fi


### PR DESCRIPTION
For 'switch.sh slot-info' all of the columns in a PFID row should be printed even if the field value could not be read.  This allows the output to be more easily parsed.

One such failure mode which has been observed:

    # switchtec-nvme id-ctrl 0x4100@/dev/switchtec1
    Getting EP tunnel status: Unknown MRPC error (MRPC: 0x8f, error: 0x1)
    NVMe status: Unknown(0x2827)