### PR TITLE
Uniform namespaces

### DIFF
--- a/pkg/manager-nnf/allocation_policy.go
+++ b/pkg/manager-nnf/allocation_policy.go
@@ -181,7 +181,7 @@ func (p *SpareAllocationPolicy) CheckAndAdjustCapacity() error {
 			}
 		}
 
-		// Adjust the pool's capacity
+		// Adjust the pool's capacity such namespaces are uniformly sized on each storage
 		p.capacityBytes = driveCapacityBytes * uint64(len(p.storage))
 	}
 

--- a/pkg/manager-nnf/allocation_policy.go
+++ b/pkg/manager-nnf/allocation_policy.go
@@ -181,7 +181,7 @@ func (p *SpareAllocationPolicy) CheckAndAdjustCapacity() error {
 			}
 		}
 
-		// Adjust the pool's capacity such namespaces are uniformly sized on each storage
+		// Adjust the pool's capacity such that it is a multiple of the number drives.
 		p.capacityBytes = driveCapacityBytes * uint64(len(p.storage))
 	}
 

--- a/pkg/manager-nnf/allocation_policy.go
+++ b/pkg/manager-nnf/allocation_policy.go
@@ -33,7 +33,7 @@ import (
 // AllocationPolicy -
 type AllocationPolicy interface {
 	Initialize(capacityBytes uint64) error
-	CheckCapacity() error
+	CheckAndAdjustCapacity() error
 	Allocate(guid uuid.UUID) ([]nvme.ProvidingVolume, error)
 }
 
@@ -124,6 +124,7 @@ type SpareAllocationPolicy struct {
 	allocatedBytes uint64
 }
 
+// Initialize the policy
 func (p *SpareAllocationPolicy) Initialize(capacityBytes uint64) error {
 
 	storage := []*nvme.Storage{}
@@ -149,7 +150,8 @@ func (p *SpareAllocationPolicy) Initialize(capacityBytes uint64) error {
 	return nil
 }
 
-func (p *SpareAllocationPolicy) CheckCapacity() error {
+// CheckAndAdjustCapacity - check the policy and adjust capacity to match policy if possible
+func (p *SpareAllocationPolicy) CheckAndAdjustCapacity() error {
 	if p.capacityBytes == 0 {
 		return fmt.Errorf("Requested capacity must be non-zero")
 	}
@@ -157,10 +159,6 @@ func (p *SpareAllocationPolicy) CheckCapacity() error {
 	var availableBytes = uint64(0)
 	for _, s := range p.storage {
 		availableBytes += s.UnallocatedBytes()
-	}
-
-	if availableBytes < p.capacityBytes {
-		return fmt.Errorf("Insufficient capacity available. Requested: %d Available: %d", p.capacityBytes, availableBytes)
 	}
 
 	if p.compliance != RelaxedAllocationComplianceType {
@@ -182,11 +180,19 @@ func (p *SpareAllocationPolicy) CheckCapacity() error {
 				return fmt.Errorf("Insufficient drive capacity available. Requested: %d Available: %d", driveCapacityBytes, s.UnallocatedBytes())
 			}
 		}
+
+		// Adjust the pool's capacity
+		p.capacityBytes = driveCapacityBytes * uint64(len(p.storage))
+	}
+
+	if availableBytes < p.capacityBytes {
+		return fmt.Errorf("Insufficient capacity available. Requested: %d Available: %d", p.capacityBytes, availableBytes)
 	}
 
 	return nil
 }
 
+// Allocate - allocate the storage
 func (p *SpareAllocationPolicy) Allocate(pid uuid.UUID) ([]nvme.ProvidingVolume, error) {
 
 	perStorageCapacityBytes := p.capacityBytes / uint64(len(p.storage))

--- a/pkg/manager-nnf/manager.go
+++ b/pkg/manager-nnf/manager.go
@@ -701,7 +701,7 @@ func (*StorageService) StorageServiceIdStoragePoolsPost(storageServiceId string,
 		return ec.NewErrInternalServerError().WithResourceType(StorageServiceOdataType).WithError(err).WithCause("Failed to initialize storage policy")
 	}
 
-	if err := policy.CheckCapacity(); err != nil {
+	if err := policy.CheckAndAdjustCapacity(); err != nil {
 		log.Error(err, "Storage policy cannot support capacity", "capacityInBytes", capacityInBytes)
 		return ec.NewErrNotAcceptable().WithResourceType(StorageServiceOdataType).WithError(err).WithCause("Insufficient capacity available")
 	}

--- a/pkg/manager-nvme/manager.go
+++ b/pkg/manager-nvme/manager.go
@@ -217,8 +217,9 @@ func findStoragePool(storageId, storagePoolId string) (*Storage, *interface{}) {
 	return nil, nil
 }
 
+// CleanupVolumes - remove all volumes other than the list of providingVolumes
 func CleanupVolumes(providingVolumes []ProvidingVolume) {
-	for _, storage := range mgr.storage {
+	for _, storage := range GetStorage() {
 		if !storage.IsEnabled() {
 			continue
 		}
@@ -456,7 +457,7 @@ func (s *Storage) purge() error {
 	return nil
 }
 
-// Delete all the volumes on this storage device except for the volumes that we want to keep
+// Delete all the volumes on this storage device other than the ones specified
 func (s *Storage) purgeVolumes(volIdsToKeep []string) error {
 	if s.device == nil {
 		return fmt.Errorf("Storage %s has no device", s.id)
@@ -551,7 +552,7 @@ func (s *Storage) deleteVolume(volumeId string) error {
 				log.Error(err, "Delete namespace failed")
 				return err
 			}
-			log.V(1).Info("Deleted namespace")
+			log.V(1).Info("Deleted namespace", "capacity", volume.capacityBytes)
 
 			s.unallocatedBytes += volume.capacityBytes
 

--- a/pkg/manager-nvme/manager.go
+++ b/pkg/manager-nvme/manager.go
@@ -110,7 +110,7 @@ type Storage struct {
 	// the life of the object.
 	capacityBytes uint64
 
-	// Unallocated capacity in bytes. This value is updated for any namespaces create or
+	// Unallocated capacity in bytes. This value is updated for any namespace create or
 	// delete operation that might shrink or grow the byte count as expected.
 	unallocatedBytes uint64
 

--- a/scripts/interactive.py
+++ b/scripts/interactive.py
@@ -55,7 +55,7 @@ class StoragePool(Command):
             size = ByteSizeStringToIntegerBytes(size)
             payload = {
                 'Capacity': {'Data': {'AllocatedBytes': int(size)}},
-                'Oem': {'Compliance': 'relaxed'}
+                'Oem': {'Compliance': 'strict'}
             }
             return payload
         except ValueError:

--- a/tools/switch.sh
+++ b/tools/switch.sh
@@ -287,7 +287,7 @@ displayStatus() {
 
         # Other Links
         [0]="Interswitch Link           "
-        [24]="Rabbit,       ${CHASSIS}r7b0n0"
+        [24]="Rabbit-p,     ${CHASSIS}r7b0n0"
         [32]="Compute 0,    ${CHASSIS}s0b0n0"
         [34]="Compute 1,    ${CHASSIS}s0b1n0"
         [36]="Compute 2,    ${CHASSIS}s1b0n0"
@@ -311,7 +311,7 @@ displayStatus() {
 
         # Other Links
         [0]="Interswitch Link           "
-        [24]="Rabbit,       ${CHASSIS}r7b0n0"
+        [24]="Rabbit-p,     ${CHASSIS}r7b0n0"
         [32]="Compute 8,    ${CHASSIS}s4b0n0"
         [34]="Compute 9,    ${CHASSIS}s4b1n0"
         [36]="Compute 10,   ${CHASSIS}s5b0n0"
@@ -370,8 +370,8 @@ displayStatus() {
 
     mapfile -t statusTableLines < <(switchtec status --format=table "$SWITCH_NAME")
 
-    printf "Switch Connection        \tStatus\tRate\tWidth\n"
-    printf "===========================\t======\t====\t=================\n"
+    printf "Port\tSwitch Connection        \tStatus\tRate\tWidth\n"
+    printf "====\t===========================\t======\t====\t=================\n"
 
     # Show the downstream ports (drives) before the upstream (computes and Rabbit-p)
     local PORT_DIRECTION=("dsp" "usp")
@@ -404,7 +404,7 @@ displayStatus() {
                             if (var1 == var2) print $3; else print $3"*";}')
                     LINK=$(echo "$line" | awk '{gsub(/link:/, "", $8); if ($8 == 1) print "UP"; else if ($8 == 0) print "DOWN"; }')
                     RATE=$(echo "$line" | awk '{gsub(/rate:/, "", $9); if ($9 == "G4") print $9; else print $9"*"; }')
-                    printf "%s\t%s\t%s\t%s\n" "$ENDPOINT" "$LINK" "$RATE" "$WIDTH"
+                    printf "%s\t%s\t%s\t%s\t%s\n" "$PHYSICAL_PORT_ID" "$ENDPOINT" "$LINK" "$RATE" "$WIDTH"
                 fi
             fi
         done
@@ -524,6 +524,15 @@ case $1 in
             TIME switchtec fabric "$FABRIC_CMD" "$SWITCH" "${ARGS[@]}"
         }
         execute fabric "${2:-gfms-dump}" "${@:3}"
+        ;;
+    diag)
+        function diag() {
+            local SWITCH=$1 DIAG_CMD=$2 ARGS=( "${@:3}" )
+            if [ "$VERBOSE" == "true" ]; then echo "Execute switch diag $DIAG_CMD"; fi
+            displayPAX "$SWITCH"
+            TIME switchtec diag "$DIAG_CMD" "$SWITCH" "${ARGS[@]}"
+        }
+        execute diag "${2:ltssm-log}" "${@:3}"
         ;;
     cmd)
         function cmd() {


### PR DESCRIPTION
- implement the `strict` allocation policy that guarantees that the capacity consumed from each drive in a storage pool is the same. This may consume more space, but the uniformity is beneficial to all users of the space.
- when namespaces that have not been assigned to a storage pool are discovered and the `deleteUnknownVolumes` command line parameter is specifed, those namespaces are deleted. This PR includes a fix that correctly returns the space to the storage devices for unknown namespaces. The result of this bug was that nnf-ec incorrectly reported out-of-space conditions when the available space on the drive was present after purging unknown namespaces.

We need a change in `nnf-sos` to request the `strict` allocation compliance which will be coming after this is merged to master.