### PR TITLE
nnf-ec segfault during storage group delete

### DIFF
--- a/internal/switchtec/cmd/config/config.go
+++ b/internal/switchtec/cmd/config/config.go
@@ -200,7 +200,7 @@ func (cmd *ConfigCmd) Run() error {
 						}
 
 						if function.Bound != 0 {
-							fmt.Printf("Alread Bound: PAX: %d PhyPort: %d LogPort %d\n", function.BoundPAXID, function.BoundHVDPhyPID, function.BoundHVDLogPID)
+							fmt.Printf("Already Bound: PAX: %d PhyPort: %d LogPort %d\n", function.BoundPAXID, function.BoundHVDPhyPID, function.BoundHVDLogPID)
 							continue
 						}
 
@@ -252,7 +252,7 @@ func validateConfig(conf ConfigFile) error {
 
 	for _, device := range conf.Devices {
 		if len(device.Domains) == 0 {
-			return configError("Atleast one domain needed for device %s", device.Metadata.Name)
+			return configError("At least one domain needed for device %s", device.Metadata.Name)
 		}
 	}
 
@@ -404,7 +404,6 @@ var (
 	}
 )
 
-//
 // The Virtualization Management Controller provides an abstraction into
 // Virtualization Management command.
 //

--- a/pkg/manager-fabric/manager.go
+++ b/pkg/manager-fabric/manager.go
@@ -1039,12 +1039,12 @@ func Initialize(log ec.Logger, ctrl SwitchtecControllerInterface) error {
 
 	// create the endpoint groups & connections
 
-	// An Endpoint Groups is created for each managment and upstream endpoints, with
+	// An Endpoint Group is created for each managment and upstream endpoint, with
 	// the associated target endpoints linked to form the group. This is conceptually
 	// equivalent to the Host Virtualization Domains that exist in the PAX Switch.
 
-	// A Connection is made for every endpoint (also representing the HVD). Connections
-	// contain the attached volumes. The two are linked.
+	// A Connection is made for every endpoint (also representing the HVD).
+	// Connections contain the attached volumes. The two are linked.
 	m.endpointGroups = make([]EndpointGroup, mangementAndUpstreamEndpointCount)
 	m.connections = make([]Connection, mangementAndUpstreamEndpointCount)
 	for endpointGroupIdx := range m.endpointGroups {
@@ -1075,7 +1075,7 @@ func Initialize(log ec.Logger, ctrl SwitchtecControllerInterface) error {
 	}
 
 	// Fabric Manager must wait for NVMe drives to be enabled prior to running the bind
-	// operation that will route drives to upstream ports. By subscribing to the event
+	// operation that routes drives to upstream ports. By subscribing to the event
 	// manager, we can receive the desired "PortAutomaticallyEnabledFabric" event and
 	// act accordingly.
 	event.EventManager.Subscribe(m)

--- a/pkg/manager-nnf/manager.go
+++ b/pkg/manager-nnf/manager.go
@@ -451,8 +451,10 @@ func (s *StorageService) Initialize(log ec.Logger, ctrl NnfControllerInterface) 
 
 	// Create the key-value storage database
 	{
-		s.store, err = persistent.Open("nnf.db", false)
+		path := "nnf.db"
+		s.store, err = persistent.Open(path, false)
 		if err != nil {
+			log.Error(err, "Unable to open database", "path", path)
 			return err
 		}
 

--- a/pkg/manager-nnf/manager.go
+++ b/pkg/manager-nnf/manager.go
@@ -436,12 +436,16 @@ func (s *StorageService) Initialize(log ec.Logger, ctrl NnfControllerInterface) 
 
 	s.endpoints = make([]Endpoint, len(conf.RemoteConfig.Servers))
 	for endpointIdx := range s.endpoints {
+		opts := server.ServerControllerOptions{
+			Local:   true,
+			Address: "",
+		}
 		s.endpoints[endpointIdx] = Endpoint{
 			id:             strconv.Itoa(endpointIdx),
 			state:          sf.UNAVAILABLE_OFFLINE_RST,
 			config:         &conf.RemoteConfig.Servers[endpointIdx],
 			storageService: s,
-			serverCtrl:     server.NewDisabledServerController(),
+			serverCtrl:     s.serverControllerProvider.NewServerController(opts),
 		}
 	}
 
@@ -527,7 +531,6 @@ func (s *StorageService) EventHandler(e event.Event) error {
 
 		} else if linkDropped {
 			log.Info("Link dropped")
-			endpoint.serverCtrl = server.NewDisabledServerController()
 			endpoint.state = sf.UNAVAILABLE_OFFLINE_RST
 		}
 

--- a/pkg/manager-nnf/storage_group.go
+++ b/pkg/manager-nnf/storage_group.go
@@ -187,7 +187,13 @@ func (rh *storageGroupRecoveryReplyHandler) Metadata(data []byte) error {
 	}
 
 	storagePool := rh.storageService.findStoragePool(metadata.StoragePoolId)
+	if storagePool == nil {
+		return fmt.Errorf("storagePool %s not found", metadata.StoragePoolId)
+	}
 	endpoint := rh.storageService.findEndpoint(metadata.EndpointId)
+	if endpoint == nil {
+		return fmt.Errorf("endpoint %s not found", metadata.EndpointId)
+	}
 
 	rh.storageService.createStorageGroup(rh.id, storagePool, endpoint)
 

--- a/pkg/manager-nnf/storage_pool.go
+++ b/pkg/manager-nnf/storage_pool.go
@@ -344,9 +344,9 @@ func (rh *storagePoolRecoveryReplayHandler) Done() (bool, error) {
 
 	case storagePoolStorageCreateCompleteLogEntryType, storagePoolStorageDeleteStartLogEntryType:
 		// Case 1. Create Complete: In this case, we've fully created the storage pool and it should be
-		// fully recoverable and place back in use.
+		// fully recoverable and placed back in use.
 
-		// Case 2. Delete Start: We started a delete but it did not finish. This means the storage pool
+		// Case 2. Delete Start: We started a delete, but it did not finish. This means the storage pool
 		// still exists, and its volumes are unknown. Here we try to recover the volumes, but ignore any
 		// errors as the volume might be deleted. The client should retry the delete, at which point we
 		// will delete any remaining volumes

--- a/tools/nnf-switch.sh
+++ b/tools/nnf-switch.sh
@@ -241,7 +241,7 @@ displayDriveSlotStatus() {
             PDFID=$(switchtec fabric gfms-dump "$SWITCH_NAME" | grep "$physicalPortString" -A2 | grep "PDFID" | awk '{print $2}')
             if [ -z "$PDFID" ]; then
                 PDFID=""
-                MF=""
+                MF="$(echo "${idCtrl[0]}" | awk '{print $3}')"
                 FW=""
                 SN=""
                 Device=""
@@ -255,10 +255,10 @@ displayDriveSlotStatus() {
                         Device="${deviceName["$SN"]}"
                         ;;
                     *)
-                        MF="$(echo "${idCtrl[0]}" | awk '{print $3}')"
-                        SN=""
-                        FW=""
-                        Device=""
+                        MF="Unavail"
+                        SN="Unavail"
+                        FW="Unavail"
+                        Device="Unavail"
                         ;;
                 esac
             fi


### PR DESCRIPTION
Allow storage groups to be created/deleted when the compute node is not connected. This eases startup for ansible-created filesystems where the compute node is powered off.

This change also has the effect of repairing a segfault that happens when nnf-ec restarts after a compute node has been powered off. nnf-ec searches for the storage group, but because the endpoint is down is not accessible. When a delete operation on storage groups for that compute node result in segfaults.