### PR TITLE
Ignore delete path errors

### DIFF
--- a/tools/nnf-nvme.sh
+++ b/tools/nnf-nvme.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2022 Hewlett Packard Enterprise Development LP
+# Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.
 #
 # The entirety of this work is licensed under the Apache License,

--- a/tools/nnf-nvme.sh
+++ b/tools/nnf-nvme.sh
@@ -212,11 +212,9 @@ case $1 in
         ;;
     list)
         function list_ns() {
-            local DRIVE=$1
-            echo "Namespaces on $DRIVE"
-            TIME switchtec-nvme list-ns "$DRIVE" --all
+            TIME switchtec-nvme switchtec list
         }
-        executeParallel list_ns
+        list_ns
         ;;
     list-pdfid)
         function list_pfid() {

--- a/tools/nnf-nvme.sh
+++ b/tools/nnf-nvme.sh
@@ -42,20 +42,20 @@ Arguments:
   -t                time each command
 
 Examples:
-  ./nvme.sh -t delete 1                                                 # delete namespace 1
+  ./nnf-nvme.sh -t delete 1                                                 # delete namespace 1
 
-  ./nvme.sh cmd id-ctrl | grep -E "^fr "                                # display firmware level
-  ./nvme.sh cmd id-ctrl | grep -E "^mn "                                # display model name
-  ./nvme.sh cmd id-ctrl | grep -e "Execute" -e "^fr " -e "^sn "         # display the drive's PDFID, firmware version, and serial number
+  ./nnf-nvme.sh cmd id-ctrl | grep -E "^fr "                                # display firmware level
+  ./nnf-nvme.sh cmd id-ctrl | grep -E "^mn "                                # display model name
+  ./nnf-nvme.sh cmd id-ctrl | grep -e "Execute" -e "^fr " -e "^sn "         # display the drive's PDFID, firmware version, and serial number
 
-  ./nvme.sh cmd format --force --ses=0 --namespace-id=<namespace id>    # format specified namespace
-  ./nvme.sh cmd list-ctrl --namespace-id=<ns-id>                        # list the controller attached to namespace "ns-id"
+  ./nnf-nvme.sh cmd format --force --ses=0 --namespace-id=<namespace id>    # format specified namespace
+  ./nnf-nvme.sh cmd list-ctrl --namespace-id=<ns-id>                        # list the controller attached to namespace "ns-id"
 
-  ./nvme.sh cmd virt-mgmt --cntlid=3 --act=9                            # enable virtual functions for Rabbit
+  ./nnf-nvme.sh cmd virt-mgmt --cntlid=3 --act=9                            # enable virtual functions for Rabbit
 
 Drive Firmware upgrade:
-  ./nvme.sh cmd fw-download --fw=<filename>.ftd                         # download firmware
-  ./nvme.sh cmd fw-activate --action=3                                  # activate latest firmware download
+  ./nnf-nvme.sh cmd fw-download --fw=<filename>.ftd                         # download firmware
+  ./nnf-nvme.sh cmd fw-activate --action=3                                  # activate latest firmware download
 
 EOF
 }

--- a/tools/nnf-switch.sh
+++ b/tools/nnf-switch.sh
@@ -44,25 +44,25 @@ Arguments:
   -t                time each command
 
 Examples:
-  ./switch.sh slot-info                                                         # display physical slot -> switch physical port status
-  ./switch.sh slot-info | grep 'Not attached'                                   # display slots without a working drive
+  ./nnf-switch.sh slot-info                                                         # display physical slot -> switch physical port status
+  ./nnf-switch.sh slot-info | grep 'Not attached'                                   # display slots without a working drive
 
-  ./switch.sh status                                                            # display connected endpoint status
-  ./switch.sh switchtec-status                                                  # display switchtec port status
-  ./switch.sh info                                                              # display switch information
+  ./nnf-switch.sh status                                                            # display connected endpoint status
+  ./nnf-switch.sh switchtec-status                                                  # display switchtec port status
+  ./nnf-switch.sh info                                                              # display switch information
 
-  ./switch.sh fabric                                                            # defaults to 'gfms-dump' command to dump the GFMS database
-  ./switch.sh fabric | grep '^PAX ID:' -A4                                      # display the number of endpoints attached to each PAX
-  ./switch.sh fabric | grep -e "Physical Port ID " -A2 -e "^PAX ID:"            # display the drive physical ports along with their PDFIDs
+  ./nnf-switch.sh fabric                                                            # defaults to 'gfms-dump' command to dump the GFMS database
+  ./nnf-switch.sh fabric | grep '^PAX ID:' -A4                                      # display the number of endpoints attached to each PAX
+  ./nnf-switch.sh fabric | grep -e "Physical Port ID " -A2 -e "^PAX ID:"            # display the drive physical ports along with their PDFIDs
 
-  ./switch.sh fabric gfms-dump                                                  # dump GFMS database (same as ./switch.sh fabric)
-  ./switch.sh fabric gfms-dump | grep -e "Execute" -e "^PAX ID:"                # display PAX ID associated with each /dev/switchtec device
-  ./switch.sh fabric gfms-dump | grep "Function 0 (SRIOV-PF)" -A1 | grep PDFID  # display the list of physical device fabric IDs for the drives attached
+  ./nnf-switch.sh fabric gfms-dump                                                  # dump GFMS database (same as ./nnf-switch.sh fabric)
+  ./nnf-switch.sh fabric gfms-dump | grep -e "Execute" -e "^PAX ID:"                # display PAX ID associated with each /dev/switchtec device
+  ./nnf-switch.sh fabric gfms-dump | grep "Function 0 (SRIOV-PF)" -A1 | grep PDFID  # display the list of physical device fabric IDs for the drives attached
 
-  ./switch.sh fabric topo-info                                                  # show topology info including PCIe rates
+  ./nnf-switch.sh fabric topo-info                                                  # show topology info including PCIe rates
 
-  ./switch.sh cmd fw-info                                                       # return information on the currently flashed firmware
-  ./switch.sh cmd fw-info | grep -A1 'Currently Running'                        # display currently running firmware
+  ./nnf-switch.sh cmd fw-info                                                       # return information on the currently flashed firmware
+  ./nnf-switch.sh cmd fw-info | grep -A1 'Currently Running'                        # display currently running firmware
 EOF
 }
 
@@ -326,7 +326,7 @@ displayStatus() {
 
     # Example switchtec status in table format
     #
-    #       [root@x9000c3j7b0n0 tools]# ./switch.sh cmd status --format=table
+    #       [root@x9000c3j7b0n0 tools]# ./nnf-switch.sh cmd status --format=table
     #       DEVICE: /dev/switchtec0 PAX_ID: 1
     #
     #       [00] part:00.01 w:cfg[x16]-neg[x16] stk:0.0 lanes:0123456789abcdef rev:0 dsp link:1 rate:G4 LTSSM:L0 (L0)

--- a/tools/nnf-switch.sh
+++ b/tools/nnf-switch.sh
@@ -18,6 +18,7 @@
 # limitations under the License.
 set -eo pipefail
 shopt -s expand_aliases
+shopt -s extglob
 
 usage() {
     cat <<EOF
@@ -93,9 +94,7 @@ function getPDFIDs() {
 }
 
 function getDriveList() {
-    # DRIVES=$1
-    # for DRIVE in $(ls /dev/nvme* | grep -E "nvme[[:digit:]]+$");
-    for DRIVE in /dev/nvme[0-9]*;
+    for DRIVE in /dev/nvme+([0-9]);
     do
         # shellcheck disable=SC2086
         if [ "$(nvme id-ctrl ${DRIVE} | grep -e KIOXIA -e 'SAMSUNG MZ3LO1T9HCJR')" != "" ];

--- a/tools/nnf-switch.sh
+++ b/tools/nnf-switch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.
 #
 # The entirety of this work is licensed under the Apache License,


### PR DESCRIPTION
Log errors and continue on the initialization and delete paths for storage groups/pools

To test these paths, I used nnf-ec standalone on the texas system and performed various deletion operations with missing namespaces.