### PR TITLE
Patch commandline parameter

### DIFF
--- a/pkg/controller.go
+++ b/pkg/controller.go
@@ -52,17 +52,22 @@ const (
 )
 
 type Options struct {
-	mock                 bool   // Enable mock interfaces for Switches, NVMe, and NNF
-	cli                  bool   // Enable CLI commands instead of binary
-	persistence          bool   // Enable persistent object storage; used during crash/reboot recovery
-	json                 string // Initialize the element controller with the provided json file
-	direct               string // Enable direct management of NVMe devices matching this regexp pattern
-	InitializeAndExit    bool   // Initialize all controllers then exit without starting the http server (mfg use)
-	deleteUnknownVolumes bool   // Delete volumes not represented by a storage pool at the end of initialization
+	mock                  bool   // Enable mock interfaces for Switches, NVMe, and NNF
+	cli                   bool   // Enable CLI commands instead of binary
+	persistence           bool   // Enable persistent object storage; used during crash/reboot recovery
+	json                  string // Initialize the element controller with the provided json file
+	direct                string // Enable direct management of NVMe devices matching this regexp pattern
+	InitializeAndExit     bool   // Initialize all controllers then exit without starting the http server (mfg use)
+	deleteUnknownVolumes  bool   // Delete volumes not represented by a storage pool at the end of initialization
+	replaceMissingVolumes bool   // Replace missing volumes in storage pools
 }
 
 func (o *Options) DeleteUnknownVolumes() bool {
 	return o.deleteUnknownVolumes
+}
+
+func (o *Options) ReplaceMissingVolumes() bool {
+	return o.replaceMissingVolumes
 }
 
 func newDefaultOptions() *Options {
@@ -83,6 +88,7 @@ func BindFlags(fs *flag.FlagSet) *Options {
 	fs.StringVar(&opts.direct, "direct", opts.direct, "Enable direct management of NVMe block devices matching this regexp pattern. Implies Mock.")
 	fs.BoolVar(&opts.InitializeAndExit, "initializeAndExit", opts.InitializeAndExit, "Initialize all hardware controllers, then exit without starting the http server. Useful in hardware bringup")
 	fs.BoolVar(&opts.deleteUnknownVolumes, "deleteUnknownVolumes", opts.deleteUnknownVolumes, "Delete volumes not represented by storage pools")
+	fs.BoolVar(&opts.replaceMissingVolumes, "replaceMissingVolumes", opts.replaceMissingVolumes, "Replace missing volumes in storage pools")
 
 	nvme.BindFlags(fs)
 
@@ -123,16 +129,16 @@ func NewController(opts *Options) *ec.Controller {
 		persistent.StorageProvider = persistent.NewJsonFilePersistentStorageProvider(opts.json)
 	}
 
-	return ec.NewController(Name, Port, Version, NewDefaultApiRouters(switchCtrl, nvmeCtrl, nnfCtrl, opts.deleteUnknownVolumes))
+	return ec.NewController(Name, Port, Version, NewDefaultApiRouters(switchCtrl, nvmeCtrl, nnfCtrl, opts.DeleteUnknownVolumes(), opts.ReplaceMissingVolumes()))
 }
 
-// NewDefaultApiRouters -
-func NewDefaultApiRouters(switchCtrl fabric.SwitchtecControllerInterface, nvmeCtrl nvme.NvmeController, nnfCtrl nnf.NnfControllerInterface, nnfUnknownVolumes bool) ec.Routers {
+// NewDefaultApiRouters - Create the default set of API routers for the NNF Element Controller
+func NewDefaultApiRouters(switchCtrl fabric.SwitchtecControllerInterface, nvmeCtrl nvme.NvmeController, nnfCtrl nnf.NnfControllerInterface, nnfUnknownVolumes bool, nnfReplaceMissingVolumes bool) ec.Routers {
 
 	routers := []ec.Router{
 		fabric.NewDefaultApiRouter(fabric.NewDefaultApiService(), switchCtrl),
 		nvme.NewDefaultApiRouter(nvme.NewDefaultApiService(), nvmeCtrl),
-		nnf.NewDefaultApiRouter(nnf.NewDefaultApiService(nnf.NewDefaultStorageService(nnfUnknownVolumes)), nnfCtrl),
+		nnf.NewDefaultApiRouter(nnf.NewDefaultApiService(nnf.NewDefaultStorageService(nnfUnknownVolumes, nnfReplaceMissingVolumes)), nnfCtrl),
 		telemetry.NewDefaultApiRouter(telemetry.NewDefaultApiService()),
 		event.NewDefaultApiRouter(event.NewDefaultApiService()),
 		msgreg.NewDefaultApiRouter(msgreg.NewDefaultApiService()),

--- a/pkg/manager-nnf/storage_group.go
+++ b/pkg/manager-nnf/storage_group.go
@@ -186,7 +186,7 @@ func (sg *StorageGroup) recoverPool() error {
 		return fmt.Errorf("recover storage group pool: storage pool %s not found", sg.storagePoolId)
 	}
 
-	log.V(1).Info("recovering storage group")
+	log.V(1).Info("recover storage group")
 
 	// Check each providing volume in the storage pool
 	for _, pv := range sp.providingVolumes {
@@ -199,13 +199,11 @@ func (sg *StorageGroup) recoverPool() error {
 			continue
 		}
 
-		// Attach the volume to the endpoint if necessary
+		// Ensure volume is attached to the endpoint
 		if err := volume.AttachControllerIfUnattached(sg.endpoint.controllerId); err != nil {
 			return err
 		}
 	}
-
-	log.V(1).Info("recovered storage group")
 
 	return nil
 }

--- a/pkg/manager-nnf/storage_pool.go
+++ b/pkg/manager-nnf/storage_pool.go
@@ -174,7 +174,6 @@ func (p *StoragePool) checkVolumes() error {
 
 	for _, pv := range volumes {
 		log := log.WithValues("serialNumber", pv.SerialNumber, "namespaceId", pv.NamespaceID)
-		log.V(2).Info("check volume", "volumeId", pv.NamespaceID)
 		storage := p.storageService.findStorage(pv.SerialNumber)
 		if storage == nil {
 			log.Info("storage device not found")
@@ -187,7 +186,7 @@ func (p *StoragePool) checkVolumes() error {
 	p.providingVolumes = p.providingVolumes[:0] // Clear the providing volumes list
 
 	if err := p.recoverVolumes(volumes); err != nil {
-		log.Error(err, "Failed to rescan volumes")
+		log.Error(err, "Failed to recover volumes")
 		return err
 	}
 

--- a/pkg/manager-nvme/manager.go
+++ b/pkg/manager-nvme/manager.go
@@ -591,8 +591,6 @@ func (s *Storage) formatVolume(volumeID string) error {
 }
 
 func (s *Storage) recoverStorageVolumes() error {
-	s.log.V(1).Info("recovering storage volumes")
-
 	namespaces, err := s.device.ListNamespaces(0)
 	if err != nil {
 		s.log.Error(err, "Failed to list device namespaces")
@@ -602,7 +600,6 @@ func (s *Storage) recoverStorageVolumes() error {
 	for _, nsid := range namespaces {
 		log := s.log.WithValues(namespaceIdKey, nsid)
 
-		log.V(2).Info("Identify namespace")
 		ns, err := s.device.IdentifyNamespace(nsid)
 		if err != nil {
 			log.Error(err, "Failed to identify namespace")
@@ -621,8 +618,6 @@ func (s *Storage) recoverStorageVolumes() error {
 		}
 
 		s.volumes = append(s.volumes, volume)
-
-		s.log.V(1).Info("recovered volume", "id", volume.id)
 	}
 
 	return nil

--- a/pkg/tests/benchmarks/benchmark_test.go
+++ b/pkg/tests/benchmarks/benchmark_test.go
@@ -39,7 +39,7 @@ func BenchmarkStorage(b *testing.B) {
 		b.Fatalf("Failed to start nnf controller")
 	}
 
-	ss := nnf.NewDefaultStorageService(true /* deleteUnknownVolumes */)
+	ss := nnf.NewDefaultStorageService(true /* deleteUnknownVolumes */, true /* replaceMissingVolumes */)
 	b.ResetTimer()
 
 	pools := make([]*sf.StoragePoolV150StoragePool, 0)

--- a/pkg/tests/filesystem/file_system_test.go
+++ b/pkg/tests/filesystem/file_system_test.go
@@ -43,7 +43,7 @@ func TestFileSystem(t *testing.T) {
 	server.FileSystemRegistry.RegisterFileSystem(testFs)
 	// TODO: defer server.FileSystemRegistry.UnregisterFileSystem(testFs)
 
-	ss := nnf.NewDefaultStorageService(true /* deleteUnknownVolumes */)
+	ss := nnf.NewDefaultStorageService(true /* deleteUnknownVolumes */, true /* replaceMissingVolumes */)
 
 	sp := &sf.StoragePoolV150StoragePool{
 		CapacityBytes: 1024 * 1024,

--- a/pkg/tests/nnf_test.go
+++ b/pkg/tests/nnf_test.go
@@ -39,7 +39,7 @@ func TestStoragePools(t *testing.T) {
 		t.Fatalf("Failed to start nnf controller")
 	}
 
-	ss := nnf.NewDefaultStorageService(true /* deleteUnknownVolumes */)
+	ss := nnf.NewDefaultStorageService(true /* deleteUnknownVolumes */, true /* replaceMissingVolumes */)
 
 	cs := &sf.CapacityCapacitySource{}
 	if err := ss.StorageServiceIdCapacitySourceGet(ss.Id(), cs); err != nil {

--- a/pkg/tests/recovery/recovery_test.go
+++ b/pkg/tests/recovery/recovery_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Reboot Recovery Testing", func() {
 				c = nnfec.NewController(nnfec.NewMockOptions(true))
 				Expect(c.Init(ec.NewDefaultOptions())).NotTo(HaveOccurred())
 
-				ss = nnf.NewDefaultStorageService(true /* deleteUnknownVolumes */)
+				ss = nnf.NewDefaultStorageService(true /* deleteUnknownVolumes */, true /* replaceMissingVolumes */)
 			})
 
 			// After each test we close the NNF Element Controller, thereby safely closing

--- a/scripts/interactive.py
+++ b/scripts/interactive.py
@@ -135,6 +135,8 @@ class StoragePool(Command):
 
         self.conn.push_path('') # Use @odata.id directly
         volumes = response.json()['Members']
+
+        counter = 1
         for volume in volumes:
             try:
                 volumeId = volume['@odata.id']
@@ -149,9 +151,13 @@ class StoragePool(Command):
                 nsid = volume.json()['Identifiers'][0]['DurableName']
                 capacityBytes = volume.json()['CapacityBytes']
 
-                print(f'{locationType} {locationValue}\t{nqn} {nsid} {capacityBytes}')
+                # Display counter for each volume
+                print(f'{counter}\t{locationType} {locationValue}\t{nqn} {nsid} {capacityBytes}')
+                # Increment counter after each volume
+                counter += 1
             except:
-                print("Missing volume")
+                print(f"{counter}: Missing volume")
+                counter += 1
 
         self.conn.pop_path()
 


### PR DESCRIPTION
# Storage Pool Volume Management Enhancement PR Summary

This PR introduces a command line parameter to control automatic storage pool volume recovery.

## Key Changes:

**Automatic Volume Replacement**
   - Added a new CLI flag `--replaceMissingVolumes` to enable automatic replacement of missing volumes in storage pools
   - Implemented logic to detect and replace missing volumes during system initialization or when storage pools are patched
   - Modified storage service initialization to support the new functionality
**New Utility**
   - Added `zpool.sh` script for creating and managing ZFS pools on Rabbit systems