### PR TITLE
Add NVMe monitoring with configurable periods and SMART log health ch…

### DIFF
--- a/internal/switchtec/cmd/fabric/perf.go
+++ b/internal/switchtec/cmd/fabric/perf.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, 2021, 2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2020-2025 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -51,7 +51,7 @@ func (cmd *BandwidthCmd) Run() error {
 		return err
 	}
 
-	// Resetting the bandwidht counter takes about 1s
+	// Resetting the bandwidth counter takes about 1s
 	time.Sleep(time.Second)
 
 	// Record the bandwidth counters

--- a/pkg/manager-fabric/manager.go
+++ b/pkg/manager-fabric/manager.go
@@ -1125,7 +1125,7 @@ func Start() error {
 	event.EventManager.Publish(msgreg.FabricReadyNnf(m.id))
 
 	// Run the Fabric Monitor in a background thread.
-	go NewFabricMonitor(m).Run()
+	StartFabricMonitor(m)
 
 	return nil
 }

--- a/pkg/manager-nnf/manager.go
+++ b/pkg/manager-nnf/manager.go
@@ -625,6 +625,8 @@ func (s *StorageService) EventHandler(e event.Event) error {
 		}
 
 		log.Info("Storage Service Enabled", "health", s.health)
+
+		nvme.StartNVMeMonitor(s.log)
 	}
 
 	// Check for storage pool events

--- a/pkg/manager-nvme/monitor.go
+++ b/pkg/manager-nvme/monitor.go
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nvme
+
+import (
+	"os"
+	"time"
+
+	"github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/nvme"
+	"github.com/NearNodeFlash/nnf-ec/pkg/ec"
+	sf "github.com/NearNodeFlash/nnf-ec/pkg/rfsf/pkg/models"
+)
+
+// StartNVMeMonitor starts a background goroutine that periodically queries all NVMe devices for their SMART log.
+func StartNVMeMonitor(log ec.Logger) {
+	// Read drive monitor period from environment variable
+	defaultDriveMonitorPeriod := 1 * time.Hour
+	driveMonitorPeriod := defaultDriveMonitorPeriod
+	if periodStr := os.Getenv("NNF_DRIVE_MONITOR_PERIOD"); periodStr != "" {
+		if d, err := time.ParseDuration(periodStr); err == nil {
+			driveMonitorPeriod = d
+		} else {
+			log.Info("Invalid NNF_DRIVE_MONITOR_PERIOD, using default", "value", driveMonitorPeriod, "error", err)
+		}
+	}
+
+	// A period of 0 means don't start the monitor.
+	if driveMonitorPeriod == 0 {
+		log.Info("Not starting NVMe monitor", "monitorPeriod", driveMonitorPeriod)
+		return
+	}
+
+	monitor := NewMonitor(log, driveMonitorPeriod)
+	go monitor.Run()
+	log.Info("Started NVMe monitor", "monitorPeriod", driveMonitorPeriod)
+}
+
+// Monitor periodically queries all NVMe devices for their SMART log
+// and can be started as a background goroutine.
+type Monitor struct {
+	Log        ec.Logger
+	Interval   time.Duration
+	GetDevices func() []*nvme.Device // Function to return all NVMe devices
+}
+
+// NewMonitor creates a new NVMe monitor with the given polling interval and device getter.
+func NewMonitor(log ec.Logger, interval time.Duration) *Monitor {
+	return &Monitor{
+		Log:      log,
+		Interval: interval,
+	}
+}
+
+// Run starts the monitor loop. It periodically calls GetSmartLog on all devices.
+func (m *Monitor) Run() {
+	log := m.Log
+	for {
+		time.Sleep(m.Interval)
+
+		storages := GetStorage()
+		// log.V(2).Info("Drive monitor tick", "period", m.Interval, "device count", len(storages))
+		for _, storage := range storages {
+			if !storage.IsEnabled() {
+				// log.V(2).Info("storage disabled", "slot", storage.Slot())
+				continue
+			}
+
+			state, err := storage.device.CheckSmartLogForStatus()
+			if err != nil {
+				log.Error(err, "smartlog request failed", "serial", storage.SerialNumber(), "slot", storage.Slot())
+				storage.state = sf.DISABLED_RST
+			}
+			if state != storage.state {
+				log.Info("smartlog state change, (see 'nnf-nvme.sh cmd smartlog' for details)", "old state", storage.state, "new state", state, "serial", storage.SerialNumber(), "slot", storage.Slot())
+				storage.state = state
+			}
+		}
+	}
+}

--- a/pkg/manager-nvme/nvme_api.go
+++ b/pkg/manager-nvme/nvme_api.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, 2021, 2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2020-2025 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -21,6 +21,7 @@ package nvme
 
 import (
 	"github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/nvme"
+	sf "github.com/NearNodeFlash/nnf-ec/pkg/rfsf/pkg/models"
 )
 
 type NvmeController interface {
@@ -65,6 +66,8 @@ type NvmeDeviceApi interface {
 	GetNamespaceFeature(namespaceId nvme.NamespaceIdentifier) ([]byte, error)
 
 	GetWearLevelAsPercentageUsed() (uint8, error)
+
+	CheckSmartLogForStatus() (sf.ResourceState, error)
 }
 
 // SecondaryControllersInitFunc -

--- a/pkg/manager-nvme/nvme_cli.go
+++ b/pkg/manager-nvme/nvme_cli.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, 2021, 2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2020-2025 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -33,6 +33,7 @@ import (
 
 	"github.com/NearNodeFlash/nnf-ec/pkg/logging"
 	fabric "github.com/NearNodeFlash/nnf-ec/pkg/manager-fabric"
+	sf "github.com/NearNodeFlash/nnf-ec/pkg/rfsf/pkg/models"
 )
 
 func NewCliNvmeController() NvmeController {
@@ -222,7 +223,7 @@ func (d *cliDevice) ListAttachedControllers(namespaceId nvme.NamespaceIdentifier
 
 func (d *cliDevice) CreateNamespace(sizeInSectors uint64, sectorSizeIndex uint8) (nvme.NamespaceIdentifier, nvme.NamespaceGloballyUniqueIdentifier, error) {
 	// Example Command
-	//    # nvme create-ns /dev/nvme2 --nsze=468843606 --ncap=468843606 --flbas=3 --nmic=1 
+	//    # nvme create-ns /dev/nvme2 --nsze=468843606 --ncap=468843606 --flbas=3 --nmic=1
 	//    create-ns: Success, created nsid:1
 
 	rsp, err := d.run(fmt.Sprintf("create-ns %s --nsze=%d --ncap=%d --flbas=%d --nmic=1", d.dev(), sizeInSectors, sizeInSectors, sectorSizeIndex))
@@ -386,6 +387,22 @@ func (d *cliDevice) GetWearLevelAsPercentageUsed() (uint8, error) {
 	err = structex.DecodeByteBuffer(bytes.NewBuffer([]byte(rsp)), log)
 
 	return log.PercentageUsed, err
+}
+
+func (d *cliDevice) CheckSmartLogForStatus() (sf.ResourceState, error) {
+	rsp, err := d.run(fmt.Sprintf("smart-log %s --output-format=binary", d.dev()))
+	if err != nil {
+		return sf.DISABLED_RST, err
+	}
+
+	log := new(nvme.SmartLog)
+
+	err = structex.DecodeByteBuffer(bytes.NewBuffer([]byte(rsp)), log)
+	if err != nil {
+		return sf.DISABLED_RST, err
+	}
+
+	return nvme.InterpretSmartLog(log), err
 }
 
 func (d *cliDevice) run(cmd string) (string, error) {

--- a/pkg/manager-nvme/nvme_device.go
+++ b/pkg/manager-nvme/nvme_device.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, 2021, 2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2020-2025 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -27,6 +27,7 @@ import (
 	fabric "github.com/NearNodeFlash/nnf-ec/pkg/manager-fabric"
 
 	"github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/nvme"
+	sf "github.com/NearNodeFlash/nnf-ec/pkg/rfsf/pkg/models"
 )
 
 type SwitchtecNvmeController struct{}
@@ -255,4 +256,14 @@ func (d *nvmeDevice) GetWearLevelAsPercentageUsed() (uint8, error) {
 	}
 
 	return log.PercentageUsed, nil
+}
+
+func (d *nvmeDevice) CheckSmartLogForStatus() (sf.ResourceState, error) {
+
+	sl, err := d.dev.GetSmartLog()
+	if err != nil {
+		return sf.DISABLED_RST, err
+	}
+
+	return nvme.InterpretSmartLog(sl), nil
 }

--- a/pkg/manager-nvme/nvme_direct_device.go
+++ b/pkg/manager-nvme/nvme_direct_device.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, 2021, 2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2020-2025 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -24,6 +24,7 @@ import (
 
 	"github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/nvme"
 	fabric "github.com/NearNodeFlash/nnf-ec/pkg/manager-fabric"
+	sf "github.com/NearNodeFlash/nnf-ec/pkg/rfsf/pkg/models"
 )
 
 type DirectNvmeController struct {
@@ -144,4 +145,8 @@ func (*nvmeDirectDevice) SetNamespaceFeature(namespaceId nvme.NamespaceIdentifie
 
 func (d *nvmeDirectDevice) GetWearLevelAsPercentageUsed() (uint8, error) {
 	return d.cliDevice.GetWearLevelAsPercentageUsed()
+}
+
+func (d *nvmeDirectDevice) CheckSmartLogForStatus() (sf.ResourceState, error) {
+	return d.cliDevice.CheckSmartLogForStatus()
 }

--- a/pkg/manager-nvme/nvme_mock.go
+++ b/pkg/manager-nvme/nvme_mock.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, 2021, 2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2020-2025 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -28,6 +28,7 @@ import (
 	"strings"
 
 	"github.com/NearNodeFlash/nnf-ec/internal/switchtec/pkg/nvme"
+	sf "github.com/NearNodeFlash/nnf-ec/pkg/rfsf/pkg/models"
 )
 
 type MockNvmeController struct {
@@ -457,4 +458,8 @@ func (d *mockDevice) findNamespace(namespaceId nvme.NamespaceIdentifier) *mockNa
 	}
 
 	return nil
+}
+
+func (*mockDevice) CheckSmartLogForStatus() (sf.ResourceState, error) {
+	return sf.ENABLED_RST, nil
 }


### PR DESCRIPTION
…ecking

* Add NVMe SMART log monitor with configurable polling interval
* Add environment variables for fabric and drive monitor periods
* Implement CheckSmartLogForStatus API
* Add health status detection based on SMART log critical warnings
* Fix fabric monitor to use configurable period instead of hardcoded 60s