### PR TITLE
Add periodic garbage collector for key-value store

### DIFF
--- a/pkg/manager-nnf/manager.go
+++ b/pkg/manager-nnf/manager.go
@@ -500,6 +500,7 @@ func (s *StorageService) Initialize(log ec.Logger, ctrl NnfControllerInterface) 
 	// Create the key-value storage database
 	{
 		path := "nnf.db"
+		persistent.SetLogger(log)
 		s.store, err = persistent.Open(path, false)
 		if err != nil {
 			log.Error(err, "Unable to open database", "path", path)

--- a/pkg/persistent/storage_api.go
+++ b/pkg/persistent/storage_api.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2022-2025 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -17,15 +17,37 @@
  * limitations under the License.
  */
 
+// Package persistent provides persistent storage functionality for key-value operations.
+// This package implements durable storage mechanisms with support for various backends.
 package persistent
 
+import (
+	"github.com/NearNodeFlash/nnf-ec/pkg/ec"
+	"github.com/go-logr/logr"
+)
+
+// Package-level logger that can be configured
+var packageLogger ec.Logger = logr.Discard()
+
+// SetLogger configures the package-level logger for all persistent storage operations
+func SetLogger(log ec.Logger) {
+	packageLogger = log.WithName("persistent")
+}
+
+// GetLogger returns the current package logger
+func GetLogger() ec.Logger {
+	return packageLogger
+}
+
+// StorageProvider is the default storage provider instance for the package
 var StorageProvider = NewLocalPersistentStorageProvider()
 
+// PersistentStorageProvider provides methods for creating persistent storage interfaces
 type PersistentStorageProvider interface {
 	NewPersistentStorageInterface(path string, readOnly bool) (PersistentStorageApi, error)
 }
 
-// Persistent Storage API provides an interface for interacting with persistent storage
+// PersistentStorageApi provides an interface for interacting with persistent storage.
 type PersistentStorageApi interface {
 	View(func(txn PersistentStorageTransactionApi) error) error
 	Update(func(txn PersistentStorageTransactionApi) error) error
@@ -34,7 +56,7 @@ type PersistentStorageApi interface {
 	Close() error
 }
 
-// Persistent Storage Transaction API provides an interface for interacting with persistent storage transactions
+// PersistentStorageTransactionApi provides an interface for interacting with persistent storage transactions
 type PersistentStorageTransactionApi interface {
 	NewIterator(prefix string) PersistentStorageIteratorApi
 	Set(key string, value []byte) error

--- a/pkg/persistent/storage_json.go
+++ b/pkg/persistent/storage_json.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2022-2025 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -22,7 +22,6 @@ package persistent
 import (
 	"encoding/json"
 	"io/ioutil"
-
 )
 
 func NewJsonFilePersistentStorageProvider(filename string) PersistentStorageProvider {
@@ -34,16 +33,22 @@ type jsonFilePersisentStorageProvider struct {
 }
 
 func (p *jsonFilePersisentStorageProvider) NewPersistentStorageInterface(name string, readOnly bool) (PersistentStorageApi, error) {
+	log := GetLogger()
+	log.Info("Opening JSON file storage", "file", p.filename, "name", name, "readOnly", readOnly)
+
 	content, err := ioutil.ReadFile(p.filename)
 	if err != nil {
+		log.Error(err, "Failed to read JSON file", "file", p.filename)
 		return nil, err
 	}
 
 	var payload map[string]map[string]string
 	if err := json.Unmarshal(content, &payload); err != nil {
+		log.Error(err, "Failed to unmarshal JSON content", "file", p.filename)
 		return nil, err
 	}
 
+	log.Info("Successfully opened JSON file storage", "name", name)
 	return &jsonPersistentStorageInterface{data: payload[name]}, nil
 }
 
@@ -66,7 +71,3 @@ func (*jsonPersistentStorageInterface) Delete(key string) error {
 func (*jsonPersistentStorageInterface) Close() error {
 	panic("unimplemented")
 }
-
-
-
-


### PR DESCRIPTION
Periodic garbage collection is required to keep the database in good shape. This commit adds the necessary apparatus to garbage collect the nnf-ec database once per day.

Fixes https://github.com/NearNodeFlash/NearNodeFlash.github.io/issues/281